### PR TITLE
Adds typescript support

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,70 @@
+declare module "tiny-markdown-editor" {
+  type CursorPosition = { col: number; row: number; node: string };
+
+  type CommandName =
+    | "bold"
+    | "italic"
+    | "strikethrough"
+    | "code"
+    | "h1"
+    | "h2"
+    | "ul"
+    | "ol"
+    | "blockquote"
+    | "hr"
+    | "insertLink"
+    | "insertImage";
+
+  type ChangeEvent = { content: string; linesDirty: boolean[] };
+
+  type SelectionEvent = {
+    focus: CursorPosition;
+    anchor: boolean;
+    commandState: Record<string | CommandName, boolean>;
+  };
+
+  type Listener<T extends "change" | "selection"> = (
+    event: T extends "change" ? ChangeEvent : SelectionEvent
+  ) => void;
+
+  type EditorParams = { element: string; content?: string; textarea?: string };
+
+  export class Editor {
+    constructor(params: EditorParams);
+
+    public getContent(): string;
+
+    public getSelection(anchor: boolean): CursorPosition | null;
+
+    public setSelection(focus: CursorPosition, anchor: boolean): void;
+
+    public paste(text: string, anchor: boolean, focus: CursorPosition): void;
+
+    public wrapSelection(
+      pre: string,
+      post: string,
+      anchor: boolean,
+      focus: CursorPosition
+    );
+
+    public addEventListener<T extends "change" | "selection">(
+      type: T,
+      listener: Listener<T>
+    ): void;
+  }
+
+  type CommandBarParams = {
+    element: string;
+    editor: Editor;
+    commands?: {
+      name: CommandName | string;
+      title: string;
+      innerHTML: string;
+      action: (editor: Editor) => void;
+      hotkey: `${string}-${string}` | `${string}=${string}-${string}`;
+    };
+  };
+  export class CommandBar {
+    constructor(params: CommandBarParams);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "lib/index.js",
   "files": [
     "dist/*",
-    "lib/*"
+    "lib/*",
+    "globals.d.ts"
   ],
+  "types": "globals.d.ts",
   "keywords": [
     "embeddable",
     "markdown",


### PR DESCRIPTION
Hey folks,

I almost didn't use this library because it didn't have typescript support. I ultimately decided on it because it is the lightest markdown editor within the JS ecosystem. In order to keep my project from barking, I had to declare module types. I thought I'd share them with y'all. Let me know if there's anything I missed -- most are directly from the docs.

Also, I think I might have submitted a PR to the wrong branch (seeing as though there's a ton of commits I'd be carrying into this one). Let me know where this should go!