### PR TITLE
Add EditorCommandName as option for command bar action

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -157,7 +157,7 @@ declare module "tiny-markdown-editor" {
         name: CommandBarCommandName | string;
         title?: string | undefined;
         innerHTML?: string;
-        action?: (editor: Editor) => void;
+        action?: EditorCommandName |  ((editor: Editor) => void);
         hotkey?: HotKey;
       };
 


### PR DESCRIPTION
Based on [this comment](https://github.com/jefago/tiny-markdown-editor/issues/23), the `action` property for a `CommandBarCommand` should be set to `h3` to use the built-in H3 action.

This PR adds `EditorCommandName` to the type for the `action` property to enable this from TypeScript