### PR TITLE
Don't show placeholder for empty content

### DIFF
--- a/jest/setup.test.js
+++ b/jest/setup.test.js
@@ -162,3 +162,21 @@ test('Change event listeners called on setContent()', async () => {
 
   return expect(promise).resolves.not.toThrow();
 });
+
+test('Placeholder is not shown for Empty content', async () => {
+  const newPage = await browser.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+
+  const content = '';
+
+  const tinymdeContent = await newPage.evaluate((content) => {
+    const tinyMDE = new TinyMDE.Editor({
+      element: 'tinymde',
+      content: '',
+    });
+    return tinyMDE.getContent();
+  }, content);
+
+  expect(tinymdeContent).toEqual(content);
+  newPage.close();
+});

--- a/src/TinyMDE.js
+++ b/src/TinyMDE.js
@@ -52,7 +52,6 @@ class Editor {
     }
 
     this.createEditorElement(element);
-    // TODO Placeholder for empty content
     this.setContent(
       typeof props.content === "string"
         ? props.content

--- a/src/TinyMDE.js
+++ b/src/TinyMDE.js
@@ -54,10 +54,11 @@ class Editor {
     this.createEditorElement(element);
     // TODO Placeholder for empty content
     this.setContent(
-      props.content ||
-        (this.textarea
-          ? this.textarea.value
-          : "# Hello TinyMDE!\nEdit **here**")
+      typeof props.content === "string"
+        ? props.content
+        : this.textarea
+        ? this.textarea.value
+        : "# Hello TinyMDE!\nEdit **here**"
     );
   }
 


### PR DESCRIPTION
This PR adds a check to see if `content` is a string before falling back to `textarea` and then the placeholder.

Closes #72 