### PR TITLE
.TinyMDE full height

### DIFF
--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -5,6 +5,7 @@
   line-height:24px;
   outline: none;
   padding:5px;
+  height: 100%;
 }
 
 .TMBlankLine {


### PR DESCRIPTION
Make the editor area be full height of the container element, so that clicking anywhere in the container brings focus to the editor. Just the first thing I did after incorporating TinyMDE in my project, and I thought maybe it's a nice default to have?

Thanks for a great library!