### PR TITLE
Fix JS generation during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,11 @@ npm install
 npm run build
 ```
 
-The latter command generates the `dist` directory. You will find the following files there:
+The latter command generates the `dist` and `lib` directories. You will find the following files there:
 
 - `dist/tiny-mde.css` and `dist/tiny-mde.min.css`: CSS files to style the editor. These can be edited at will to make the editor look like you want to. `dist/tiny-mde.min.css` has the same content as `dist/tiny-mde.css`, it's just minified. You will only need to use one of the files on your page. If you want to edit the CSS file, it's easier to edit `dist/tiny-mde.css` and then minify the edited version.
 - `dist/tiny-mde.js`: Debug version of the editor. The JS file is not minified and contains a sourcemap. It is not recommended to use this in production settings, since the file is large.
 - `dist/tiny-mde.min.js`: Minified JS file for most use cases. Simply copy this to your project to use it.
 - `dist/tiny-mde.tiny.js`: Minified and stripped-down JS file. Contains only the editor itself, not the toolbar.
+- `lib/*.js`: Plain JavaScript versions of the code, transpiled from the TypeScript source, for use by bundlers.
+- `lib/*.d.ts`: TypeScript type declarations.

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -87,7 +87,7 @@ const jsTiny = () =>
 
 const js = gulp.series(jsMax, jsTiny);
 
-const typecheck = () => {
+const transpile = () => {
   const tsProject = gulpTypescript.createProject('tsconfig.json', {
     module: 'commonjs',
     declaration: true,
@@ -226,7 +226,7 @@ const gitPushTag = async () => {
 };
 
 
-const build = gulp.series(clean, typecheck, svg, js, css, html);
+const build = gulp.series(clean, transpile, svg, js, css, html);
 
 const dev = gulp.series(clean, svg, jsMax, css, html, watch);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "files": [
     "dist/*",
-    "lib/*",
+    "lib/**/*.js",
     "lib/**/*.d.ts"
   ],
   "types": "lib/index.d.ts",
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "test": "npx gulp && npx jest",
+    "typecheck": "npx tsc --noEmit",
     "test:chromium": "npx gulp && npx jest --selectProjects chromium",
     "test:firefox": "npx gulp && npx jest --selectProjects firefox",
     "test:webkit": "npx gulp && npx jest --selectProjects webkit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "noEmit": true
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Fixes #120.

When updating the build script to publish the npm package directly from GitHub actions, I accidentally removed the inclusion of plain JS in the bundle, which broke the ability to bundle the package. This fixes that.