### PR TITLE
Fix scrolling into view on enter

### DIFF
--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -719,6 +719,15 @@ export class Editor {
     }
     this.updateFormatting();
     this.setSelection(focus);
+
+    // Scroll the element containing the selection into view
+    if (focus && focus.row < this.lineElements.length) {
+      (this.lineElements[focus.row] as HTMLElement).scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest'
+      });
+    }
+
     this.fireChange();
   }
 


### PR DESCRIPTION
Fixes #122

Due to the recent change of making paragraph breaks happen in the beforeinput handler instead of the input handler (and cancelling the default behavior for `insertParagraph` and `insertLineBreak` input events), the browser no longer scrolled the new paragraph into view when hitting enter. This PR fixes that.