### PR TITLE
Fix support for non-QWERTY keyboard shortcuts

### DIFF
--- a/src/TinyMDECommandBar.ts
+++ b/src/TinyMDECommandBar.ts
@@ -283,10 +283,13 @@ export class CommandBar {
             command: commandName,
           };
           
-          if (keys[keys.length - 1].match(/^[0-9]$/)) {
-            hotkey.code = `Digit${keys[keys.length - 1]}`;
+          const lastKey = keys[keys.length - 1];
+          if (lastKey.match(/^[0-9]$/)) {
+            hotkey.code = `Digit${lastKey}`;
+          } else if (lastKey.match(/^[a-zA-Z]$/)) {
+            hotkey.code = `Key${lastKey.toUpperCase()}`;
           } else {
-            hotkey.key = keys[keys.length - 1].toLowerCase();
+            hotkey.key = lastKey.toLowerCase();
           }
           this.hotkeys.push(hotkey);
           title = title.concat(` (${modifierexplanation.join("+")})`);


### PR DESCRIPTION
Fixes #124

Hotkey detection was using `event.key` for letter keys, which is keyboard layout-dependent. When a user has a Russian keyboard layout, pressing the physical "B" key produces a different event.key value (the Russian character "и").

The solution is to use event.code instead, which represents the physical key location and is layout-independent.