### PR TITLE
Bump checkout and setup-node actions to v5

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release   # <-- match the npm Trusted Publisher config if you used one
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 → v5 in both workflows
- Bump `actions/setup-node` from v4 → v5 in both workflows
- v5 of these actions runs on Node.js 24, resolving the GitHub Actions Node.js 20 deprecation warning

## Test plan
- [ ] PR Tests workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)