### PR TITLE
chore: enforce 7-day minimum release age for npm deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
## Summary
- Adds `minimum-release-age=10080` (7 days) to `.npmrc`
- Mitigates supply-chain attacks via freshly-published malicious package versions (e.g. compromised maintainer tokens that push a patch within hours)

## Notes
- Honored by pnpm 10+ and npm 11.5+
- Older package-manager versions silently ignore the setting
- If a fresh dep is urgently needed, override per-install with `--allow-newer` (pnpm) or temporarily remove the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)