### PR TITLE
fix: use correct npm config name and unit for min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-minimum-release-age=10080
+min-release-age=7


### PR DESCRIPTION
## Summary
- Fix the `.npmrc` setting added in the previous PR
- The npm config name is `min-release-age` (not `minimum-release-age` — that is the pnpm name)
- Its value is in **days**, not minutes — set to `7`
- Without this fix, npm just warns `Unknown project config "minimum-release-age"` and the dependency-age protection is silently skipped

## Notes
- Supported by npm 11.10+; older npm silently ignores it
- pnpm-managed repos in this org still use `minimum-release-age` in minutes — those PRs were correct and are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)