### PR TITLE
feat: support inline styles spanning multiple lines (#166)

### DIFF
--- a/jest/inline.test.js
+++ b/jest/inline.test.js
@@ -159,11 +159,13 @@ test('Strikethrough does not need to be left or right flanking: ~~ A ~~', async 
 });
 
 test('Emphasis and strikethrough bind left to right: *A ~~B* C~~', async () =>  {
-  const editor = await initTinyMDE('*XXXA ~~XXXB* XXXC~~\n~~XXXA *XXXB~~ XXXC*');
+  // The two cases are kept in separate paragraphs (blank line between) so each is parsed on its
+  // own; adjacent lines would now form a single paragraph and parse together (see issue #166).
+  const editor = await initTinyMDE('*XXXA ~~XXXB* XXXC~~\n\n~~XXXA *XXXB~~ XXXC*');
   expect(await editor.lineHTML(0)).toMatch(/<em.*>/);
   expect(await editor.lineHTML(0)).not.toMatch(/<del.*>/);
-  expect(await editor.lineHTML(1)).not.toMatch(/<em.*>/);
-  expect(await editor.lineHTML(1)).toMatch(/<del.*>/);
+  expect(await editor.lineHTML(2)).not.toMatch(/<em.*>/);
+  expect(await editor.lineHTML(2)).toMatch(/<del.*>/);
   editor.destroy();
 });
 

--- a/jest/interaction.test.js
+++ b/jest/interaction.test.js
@@ -314,3 +314,61 @@ test("Pasting image with URL containing HTML entity-like text preserves URL (bug
   expect(html).toContain("&amp;center=1");
   expect(html).not.toContain("¢er=1"); // Should not convert &cent to ¢
 });
+
+test("Splitting a multi-line emphasis paragraph re-renders the now-standalone line (bug #166)", async () => {
+  await page.evaluate(() => {
+    document.tinyMDE = new TinyMDE.Editor({
+      element: "tinymde",
+      content: "**dolore\nmagna**",
+    });
+    document.getElementById("tinymde").firstChild.focus();
+  });
+  // Initially the strong emphasis spans both lines.
+  expect(
+    await page.$eval("#tinymde > :first-child > :nth-child(1)", (el) => el.innerHTML)
+  ).toMatch(/<strong[^>]*>dolore<\/strong>/);
+
+  // Insert a blank line between the two lines, breaking them into two paragraphs.
+  await select(page, 0, 8); // end of "**dolore"
+  await page.keyboard.press("Enter");
+  expect(await page.evaluate(() => document.tinyMDE.getContent())).toEqual(
+    "**dolore\n\nmagna**"
+  );
+
+  // The first line is now a standalone paragraph; the unmatched ** must no longer be bold,
+  // even though that line's own text never changed.
+  expect(
+    await page.$eval("#tinymde > :first-child > :nth-child(1)", (el) => el.innerHTML)
+  ).not.toMatch(/<strong/);
+});
+
+test("Merging two paragraphs activates emphasis spanning the join (bug #166)", async () => {
+  await page.evaluate(() => {
+    document.tinyMDE = new TinyMDE.Editor({
+      element: "tinymde",
+      content: "**dolore\n\nmagna**",
+    });
+    document.getElementById("tinymde").firstChild.focus();
+  });
+  // Initially neither delimiter is matched.
+  expect(
+    await page.$eval("#tinymde > :first-child > :nth-child(1)", (el) => el.innerHTML)
+  ).not.toMatch(/<strong/);
+
+  // Delete the blank line, merging the two lines into a single paragraph. Backspacing from the
+  // start of the third line removes the newline before it, pulling "magna**" onto the (empty)
+  // second line.
+  await select(page, 2, 0); // start of "magna**"
+  await page.keyboard.press("Backspace");
+  expect(await page.evaluate(() => document.tinyMDE.getContent())).toEqual(
+    "**dolore\nmagna**"
+  );
+
+  // Now the strong emphasis spans the join and both lines must show it.
+  expect(
+    await page.$eval("#tinymde > :first-child > :nth-child(1)", (el) => el.innerHTML)
+  ).toMatch(/<strong[^>]*>dolore<\/strong>/);
+  expect(
+    await page.$eval("#tinymde > :first-child > :nth-child(2)", (el) => el.innerHTML)
+  ).toMatch(/<strong[^>]*>magna<\/strong>/);
+});

--- a/jest/multiline-inline.test.js
+++ b/jest/multiline-inline.test.js
@@ -93,3 +93,57 @@ test("a single-line paragraph still renders emphasis as before", async () => {
   expect(await editor.lineHTML(0)).toMatch(/<em[^>]*>one<\/em>/);
   editor.destroy();
 });
+
+// Blockquotes -------------------------------------------------------------------------------
+
+test("emphasis spans consecutive blockquote lines", async () => {
+  const editor = await initTinyMDE("> foo **bar\n> baz** qux");
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>bar<\/strong>/);
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>baz<\/strong>/);
+  // The `>` markers are preserved on each line.
+  expect(await editor.lineText(0)).toEqual("> foo **bar");
+  expect(await editor.lineText(1)).toEqual("> baz** qux");
+  editor.destroy();
+});
+
+test("emphasis does not span a blank line inside a blockquote", async () => {
+  const editor = await initTinyMDE("> foo **bar\n>\n> baz** qux");
+  // The empty `>` line separates two paragraphs within the quote, so neither ** is matched.
+  expect(await editor.lineHTML(0)).not.toMatch(/<strong/);
+  expect(await editor.lineHTML(2)).not.toMatch(/<strong/);
+  editor.destroy();
+});
+
+test("emphasis spans a blockquote line and its lazy paragraph continuation", async () => {
+  const editor = await initTinyMDE("> foo **bar\nbaz** qux");
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>bar<\/strong>/);
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>baz<\/strong>/);
+  editor.destroy();
+});
+
+// Lists -------------------------------------------------------------------------------------
+
+test("emphasis spans a list item and its wrapped continuation line", async () => {
+  const editor = await initTinyMDE("- foo **bar\ncontinues** here");
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>bar<\/strong>/);
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>continues<\/strong>/);
+  // The bullet marker is preserved on the first line only.
+  expect(await editor.lineText(0)).toEqual("- foo **bar");
+  expect(await editor.lineText(1)).toEqual("continues** here");
+  editor.destroy();
+});
+
+test("emphasis spans an ordered list item and its continuation line", async () => {
+  const editor = await initTinyMDE("1. foo **bar\ncontinues** here");
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>bar<\/strong>/);
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>continues<\/strong>/);
+  editor.destroy();
+});
+
+test("emphasis does NOT span across two separate list items", async () => {
+  const editor = await initTinyMDE("- foo **bar\n- baz** qux");
+  // Each `- ` starts a new item, so the two ** delimiters belong to different items: no match.
+  expect(await editor.lineHTML(0)).not.toMatch(/<strong/);
+  expect(await editor.lineHTML(1)).not.toMatch(/<strong/);
+  editor.destroy();
+});

--- a/jest/multiline-inline.test.js
+++ b/jest/multiline-inline.test.js
@@ -1,0 +1,95 @@
+// Tests for inline styles (bold, italic, strikethrough, ...) that span more than one source line
+// within a single paragraph (GitHub issue #166). Consecutive paragraph lines form a single
+// CommonMark paragraph joined by soft line breaks, so emphasis opened on one line can be closed
+// on a later line. Each line is still rendered into its own block element, so any element that
+// straddles a line break is closed at the end of one line and re-opened at the start of the next.
+
+test("strong emphasis spanning two lines is detected on both lines", async () => {
+  const editor = await initTinyMDE("**dolore\nmagna**");
+  // Opening line: the run starts here and is left open at the line break.
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>dolore<\/strong>/);
+  // Closing line: the run is re-opened at the start and closed here.
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>magna<\/strong>/);
+  editor.destroy();
+});
+
+test("emphasis spanning two lines is detected on both lines", async () => {
+  const editor = await initTinyMDE("*dolore\nmagna*");
+  expect(await editor.lineHTML(0)).toMatch(/<em[^>]*>dolore<\/em>/);
+  expect(await editor.lineHTML(1)).toMatch(/<em[^>]*>magna<\/em>/);
+  editor.destroy();
+});
+
+test("strikethrough spanning two lines is detected on both lines", async () => {
+  const editor = await initTinyMDE("~~dolore\nmagna~~");
+  expect(await editor.lineHTML(0)).toMatch(/<del[^>]*>dolore<\/del>/);
+  expect(await editor.lineHTML(1)).toMatch(/<del[^>]*>magna<\/del>/);
+  editor.destroy();
+});
+
+test("the example from issue #166 is rendered correctly", async () => {
+  const editor = await initTinyMDE(
+    "Lorem **ipsum** dolor sit amet, consectetur adipiscing elit,\n" +
+      "sed do eiusmod tempor incididunt ut labore et **dolore\n" +
+      "magna** aliqua."
+  );
+  // "ipsum" is bold and fully contained on the first line.
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>ipsum<\/strong>/);
+  // "dolore magna" is bold across the second and third lines.
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>dolore<\/strong>/);
+  expect(await editor.lineHTML(2)).toMatch(/<strong[^>]*>magna<\/strong>/);
+  editor.destroy();
+});
+
+test("emphasis spanning three lines is detected on every line", async () => {
+  const editor = await initTinyMDE("*aaa\nbbb\nccc*");
+  expect(await editor.lineHTML(0)).toMatch(/<em[^>]*>aaa<\/em>/);
+  expect(await editor.lineHTML(1)).toMatch(/<em[^>]*>bbb<\/em>/);
+  expect(await editor.lineHTML(2)).toMatch(/<em[^>]*>ccc<\/em>/);
+  editor.destroy();
+});
+
+test("each rendered line's text content still equals the source line", async () => {
+  const editor = await initTinyMDE("a **bold\ntext** b");
+  // The marks stay on the line they were typed on, so the text content is unchanged.
+  expect(await editor.lineText(0)).toEqual("a **bold");
+  expect(await editor.lineText(1)).toEqual("text** b");
+  editor.destroy();
+});
+
+test("emphasis does not span across a blank line (paragraph boundary)", async () => {
+  const editor = await initTinyMDE("**dolore\n\nmagna**");
+  // Each paragraph is parsed on its own; neither delimiter has a partner, so no <strong>.
+  expect(await editor.lineHTML(0)).not.toMatch(/<strong/);
+  expect(await editor.lineHTML(2)).not.toMatch(/<strong/);
+  editor.destroy();
+});
+
+test("emphasis does not span across a heading", async () => {
+  const editor = await initTinyMDE("**dolore\n# Heading\nmagna**");
+  expect(await editor.lineHTML(0)).not.toMatch(/<strong/);
+  expect(await editor.lineHTML(2)).not.toMatch(/<strong/);
+  editor.destroy();
+});
+
+test("nested emphasis spanning a line break is rebalanced on both lines", async () => {
+  const editor = await initTinyMDE("**_aaa\nbbb_**");
+  expect(await editor.lineHTML(0)).toMatch(/<strong[^>]*>.*<em[^>]*>aaa<\/em>.*<\/strong>/);
+  expect(await editor.lineHTML(1)).toMatch(/<strong[^>]*>.*<em[^>]*>bbb<\/em>.*<\/strong>/);
+  editor.destroy();
+});
+
+test("an unclosed delimiter across lines stays literal on both lines", async () => {
+  const editor = await initTinyMDE("**dolore\nmagna");
+  expect(await editor.lineHTML(0)).not.toMatch(/<strong/);
+  expect(await editor.lineHTML(1)).not.toMatch(/<strong/);
+  expect(await editor.lineText(0)).toEqual("**dolore");
+  expect(await editor.lineText(1)).toEqual("magna");
+  editor.destroy();
+});
+
+test("a single-line paragraph still renders emphasis as before", async () => {
+  const editor = await initTinyMDE("just *one* line");
+  expect(await editor.lineHTML(0)).toMatch(/<em[^>]*>one<\/em>/);
+  editor.destroy();
+});

--- a/jest/util/test-helpers.js
+++ b/jest/util/test-helpers.js
@@ -26,6 +26,11 @@ global.initTinyMDE = async (content) => {
         `#tinymde > :first-child > :nth-child(${lineNum + 1})`,
         (el) => el.innerHTML
       ),
+    lineText: async (lineNum) =>
+      newPage.$eval(
+        `#tinymde > :first-child > :nth-child(${lineNum + 1})`,
+        (el) => el.textContent
+      ),
     numLines: async () =>
       newPage.$eval(`#tinymde > :first-child`, (el) => el.childNodes.length),
 

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -327,23 +327,55 @@ export class Editor {
   private applyLineTypes(): void {
     let lineNum = 0;
     while (lineNum < this.lines.length) {
-      // Consecutive paragraph lines form a single CommonMark paragraph and are parsed together
-      // so that inline styles (bold, italic, ...) can span the soft line breaks between them.
-      if (this.lineTypes[lineNum] === "TMPara") {
-        let groupEnd = lineNum;
+      // A "block" whose text flows across several source lines (a paragraph, a multi-line
+      // blockquote, or a list item with wrapped/lazy-continuation lines) is rendered as one
+      // inline-parsing unit so that inline styles (bold, italic, ...) can span the soft line
+      // breaks between its lines.
+      if (this.isInlineGroupLeader(lineNum)) {
+        const leaderType = this.lineTypes[lineNum];
+        let end = lineNum;
         while (
-          groupEnd + 1 < this.lines.length &&
-          this.lineTypes[groupEnd + 1] === "TMPara"
+          end + 1 < this.lines.length &&
+          this.isInlineContinuation(end + 1, leaderType)
         ) {
-          groupEnd++;
+          end++;
         }
-        this.applyParagraphGroup(lineNum, groupEnd);
-        lineNum = groupEnd + 1;
+        this.applyInlineGroup(lineNum, end);
+        lineNum = end + 1;
       } else {
         this.applyLine(lineNum);
         lineNum++;
       }
     }
+  }
+
+  /** A line that can begin a multi-line inline group (a paragraph-bearing block). */
+  private isInlineGroupLeader(lineNum: number): boolean {
+    const t = this.lineTypes[lineNum];
+    if (t === "TMPara" || t === "TMUL" || t === "TMOL") return true;
+    // A blockquote line whose content is blank is a paragraph break inside the quote, so it
+    // doesn't start (or join) a group.
+    if (t === "TMBlockquote") return !this.isBlankBlockquoteContent(lineNum);
+    return false;
+  }
+
+  /** Whether `lineNum` continues the inline group whose leader has type `leaderType`. */
+  private isInlineContinuation(lineNum: number, leaderType: string): boolean {
+    const t = this.lineTypes[lineNum];
+    // A plain paragraph line is a lazy continuation of the preceding block (paragraph, list item,
+    // or blockquote). Consecutive list markers (TMUL/TMOL), by contrast, each start a new item
+    // and therefore do NOT continue the group.
+    if (t === "TMPara") return true;
+    if (t === "TMBlockquote" && leaderType === "TMBlockquote")
+      return !this.isBlankBlockquoteContent(lineNum);
+    return false;
+  }
+
+  /** True when a blockquote line carries no (non-whitespace) content, e.g. `>` or `> `. */
+  private isBlankBlockquoteContent(lineNum: number): boolean {
+    const cap = this.lineCaptures[lineNum];
+    const content = cap && cap[2] !== undefined ? cap[2] : "";
+    return /^\s*$/.test(content);
   }
 
   private applyLine(lineNum: number): void {
@@ -356,25 +388,36 @@ export class Editor {
       el.className = this.lineTypes[lineNum];
       el.removeAttribute("style");
       el.innerHTML = contentHTML === "" ? "<br />" : contentHTML;
-      // This line is no longer rendered as part of a multi-line paragraph group.
+      // This line is no longer rendered as part of a multi-line inline group.
       delete el.dataset.mlSig;
     }
     el.dataset.lineNum = lineNum.toString();
   }
 
   /**
-   * Renders a run of consecutive paragraph lines [start..end]. The lines are joined with newlines
-   * and inline-parsed as a single unit so that emphasis/strong/strikethrough can span the soft
-   * line breaks, then the resulting HTML is split back into one fragment per source line so each
-   * line keeps its own (well-formed) block element. A single-line paragraph (start === end) is
-   * rendered exactly as before.
+   * Renders a group of lines [start..end] that together form one inline-parsing unit. The inline
+   * content of each line (the `$$N` portion of its replacement — the whole line for a paragraph,
+   * the text after the marker for a list item or blockquote) is joined with newlines and parsed as
+   * a single unit, so inline styles can span the soft line breaks. The resulting HTML is split back
+   * into one fragment per line; any element still open at a line break is closed and re-opened so
+   * each line keeps its own well-formed block element. Per-line markers (list bullets, blockquote
+   * `>`) are preserved exactly. A single-line group (start === end) renders identically to before.
    */
-  private applyParagraphGroup(start: number, end: number): void {
-    const joined = this.lines.slice(start, end + 1).join("\n");
-    // Signature of the exact content this group was rendered from. Stored on each line element so
-    // we can detect when a group needs re-rendering even if the individual line wasn't marked
-    // dirty (e.g. an edit to a sibling line, or the group's boundaries shifting on a split/merge).
-    const sig = `${end - start}:${joined.length}:${this.hashString(joined)}`;
+  private applyInlineGroup(start: number, end: number): void {
+    // Signature of every input that affects this group's rendering (line types, replacements and
+    // captures — hence the marker prefixes and the inline content). Stored per line element so a
+    // group is re-rendered whenever its content, a sibling line, or its boundaries change (e.g. on
+    // a split/merge) even if the individual line wasn't separately marked dirty.
+    const contents: string[] = [];
+    let sigSource = `${end - start}`;
+    for (let i = start; i <= end; i++) {
+      const idx = this.inlineContentIndex(this.lineReplacements[i]);
+      contents.push(this.lineCaptures[i][idx] !== undefined ? this.lineCaptures[i][idx] : "");
+      sigSource += `\x1f${this.lineTypes[i]}\x1f${this.lineReplacements[i]}\x1f${JSON.stringify(
+        this.lineCaptures[i]
+      )}`;
+    }
+    const sig = `${this.hashString(sigSource)}`;
 
     let needsRender = false;
     for (let i = start; i <= end; i++) {
@@ -389,16 +432,19 @@ export class Editor {
 
     if (needsRender) {
       const fragments = this.splitInlineHTMLByLine(
-        this.processInlineStyles(joined)
+        this.processInlineStyles(contents.join("\n"))
       );
       for (let i = start; i <= end; i++) {
         const el = this.lineElements[i] as HTMLElement;
         const frag = fragments[i - start] || "";
+        const contentHTML = this.replaceWithInline(
+          this.lineReplacements[i],
+          this.lineCaptures[i],
+          frag
+        );
         el.className = this.lineTypes[i];
         el.removeAttribute("style");
-        el.innerHTML = `<span class="TMInlineFormatted">${
-          frag === "" ? "<br />" : frag
-        }</span>`;
+        el.innerHTML = contentHTML === "" ? "<br />" : contentHTML;
         el.dataset.mlSig = sig;
       }
     }
@@ -406,6 +452,28 @@ export class Editor {
     for (let i = start; i <= end; i++) {
       (this.lineElements[i] as HTMLElement).dataset.lineNum = i.toString();
     }
+  }
+
+  /** Index of the inline-content placeholder (`$$N`) in a line replacement, or 0 if none. */
+  private inlineContentIndex(replacement: string): number {
+    const m = /\$\$([0-9])/.exec(replacement);
+    return m ? parseInt(m[1]) : 0;
+  }
+
+  /**
+   * Like replace(), but uses a pre-computed inline fragment for the `$$N` (inline content)
+   * placeholder instead of inline-parsing the capture itself. Used for multi-line groups where the
+   * inline content was parsed jointly across all lines.
+   */
+  private replaceWithInline(
+    replacement: string,
+    capture: RegExpExecArray,
+    inlineFragment: string
+  ): string {
+    return replacement.replace(/(\${1,2})([0-9])/g, (str, p1, p2) => {
+      if (p1 === "$") return htmlescape(capture[parseInt(p2)]);
+      else return `<span class="TMInlineFormatted">${inlineFragment}</span>`;
+    });
   }
 
   /**

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -325,19 +325,148 @@ export class Editor {
   }
 
   private applyLineTypes(): void {
-    for (let lineNum = 0; lineNum < this.lines.length; lineNum++) {
-      if (this.lineDirty[lineNum]) {
-        let contentHTML = this.replace(
-          this.lineReplacements[lineNum],
-          this.lineCaptures[lineNum]
-        );
-        (this.lineElements[lineNum] as HTMLElement).className = this.lineTypes[lineNum];
-        (this.lineElements[lineNum] as HTMLElement).removeAttribute("style");
-        (this.lineElements[lineNum] as HTMLElement).innerHTML =
-          contentHTML === "" ? "<br />" : contentHTML;
+    let lineNum = 0;
+    while (lineNum < this.lines.length) {
+      // Consecutive paragraph lines form a single CommonMark paragraph and are parsed together
+      // so that inline styles (bold, italic, ...) can span the soft line breaks between them.
+      if (this.lineTypes[lineNum] === "TMPara") {
+        let groupEnd = lineNum;
+        while (
+          groupEnd + 1 < this.lines.length &&
+          this.lineTypes[groupEnd + 1] === "TMPara"
+        ) {
+          groupEnd++;
+        }
+        this.applyParagraphGroup(lineNum, groupEnd);
+        lineNum = groupEnd + 1;
+      } else {
+        this.applyLine(lineNum);
+        lineNum++;
       }
-      (this.lineElements[lineNum] as HTMLElement).dataset.lineNum = lineNum.toString();
     }
+  }
+
+  private applyLine(lineNum: number): void {
+    const el = this.lineElements[lineNum] as HTMLElement;
+    if (this.lineDirty[lineNum]) {
+      let contentHTML = this.replace(
+        this.lineReplacements[lineNum],
+        this.lineCaptures[lineNum]
+      );
+      el.className = this.lineTypes[lineNum];
+      el.removeAttribute("style");
+      el.innerHTML = contentHTML === "" ? "<br />" : contentHTML;
+      // This line is no longer rendered as part of a multi-line paragraph group.
+      delete el.dataset.mlSig;
+    }
+    el.dataset.lineNum = lineNum.toString();
+  }
+
+  /**
+   * Renders a run of consecutive paragraph lines [start..end]. The lines are joined with newlines
+   * and inline-parsed as a single unit so that emphasis/strong/strikethrough can span the soft
+   * line breaks, then the resulting HTML is split back into one fragment per source line so each
+   * line keeps its own (well-formed) block element. A single-line paragraph (start === end) is
+   * rendered exactly as before.
+   */
+  private applyParagraphGroup(start: number, end: number): void {
+    const joined = this.lines.slice(start, end + 1).join("\n");
+    // Signature of the exact content this group was rendered from. Stored on each line element so
+    // we can detect when a group needs re-rendering even if the individual line wasn't marked
+    // dirty (e.g. an edit to a sibling line, or the group's boundaries shifting on a split/merge).
+    const sig = `${end - start}:${joined.length}:${this.hashString(joined)}`;
+
+    let needsRender = false;
+    for (let i = start; i <= end; i++) {
+      if (
+        this.lineDirty[i] ||
+        (this.lineElements[i] as HTMLElement).dataset.mlSig !== sig
+      ) {
+        needsRender = true;
+        break;
+      }
+    }
+
+    if (needsRender) {
+      const fragments = this.splitInlineHTMLByLine(
+        this.processInlineStyles(joined)
+      );
+      for (let i = start; i <= end; i++) {
+        const el = this.lineElements[i] as HTMLElement;
+        const frag = fragments[i - start] || "";
+        el.className = this.lineTypes[i];
+        el.removeAttribute("style");
+        el.innerHTML = `<span class="TMInlineFormatted">${
+          frag === "" ? "<br />" : frag
+        }</span>`;
+        el.dataset.mlSig = sig;
+      }
+    }
+
+    for (let i = start; i <= end; i++) {
+      (this.lineElements[i] as HTMLElement).dataset.lineNum = i.toString();
+    }
+  }
+
+  /**
+   * Splits inline HTML produced for a joined multi-line paragraph back into one fragment per
+   * source line (fragments are separated by the `\n` markers emitted by processInlineStyles).
+   * Inline elements that are still open at a line break are closed at the end of the fragment and
+   * re-opened at the start of the next one, so that every fragment is independently well-formed
+   * while the formatting visually continues across the lines.
+   */
+  private splitInlineHTMLByLine(html: string): string[] {
+    const fragments: string[] = [];
+    const openTags: string[] = []; // full opening-tag strings of currently open elements
+    let current = "";
+    let i = 0;
+    while (i < html.length) {
+      const ch = html[i];
+      if (ch === "\n") {
+        // Close currently open tags (in reverse) to finish this line's fragment ...
+        for (let t = openTags.length - 1; t >= 0; t--) {
+          current += `</${this.inlineTagName(openTags[t])}>`;
+        }
+        fragments.push(current);
+        // ... and re-open them (in order) at the start of the next line's fragment.
+        current = openTags.join("");
+        i++;
+      } else if (ch === "<") {
+        const close = html.indexOf(">", i);
+        if (close < 0) {
+          // Defensive: malformed output, emit the remainder verbatim.
+          current += html.substr(i);
+          break;
+        }
+        const tag = html.substring(i, close + 1);
+        current += tag;
+        if (tag[1] === "/") {
+          openTags.pop();
+        } else if (tag[tag.length - 2] !== "/") {
+          // Opening tag that isn't self-closing.
+          openTags.push(tag);
+        }
+        i = close + 1;
+      } else {
+        current += ch;
+        i++;
+      }
+    }
+    fragments.push(current);
+    return fragments;
+  }
+
+  private inlineTagName(openTag: string): string {
+    const m = /^<\s*([a-zA-Z][a-zA-Z0-9]*)/.exec(openTag);
+    return m ? m[1] : "span";
+  }
+
+  private hashString(s: string): number {
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) {
+      h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
+    }
+    return h;
   }
 
   private updateLineTypes(): void {
@@ -863,6 +992,18 @@ export class Editor {
     let string = originalString;
 
     outer: while (string) {
+      // Soft line break: when a paragraph that spans several source lines is parsed as one
+      // joined string, the lines are separated by \n. Preserve it as a newline marker in the
+      // output; splitInlineHTMLByLine() later splits the result back into per-line fragments.
+      // No inline rule starts on a newline (NotTriggerChar and `.` both exclude it), so handling
+      // it here keeps the tokenizer from stalling.
+      if (string.charCodeAt(0) === 10) {
+        processed += "\n";
+        string = string.substr(1);
+        offset += 1;
+        continue outer;
+      }
+
       // Process simple rules (non-delimiter)
       for (let rule of ["escape", "code", "autolink", "html"]) {
         if (this.mergedInlineGrammar[rule]) {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -39,8 +39,11 @@ export interface LineCommand {
 export type Command = InlineCommand | LineCommand;
 
 const replacements: Record<string, RegExp> = {
-  ASCIIPunctuation: /[!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~\\]/,  
-  NotTriggerChar: /[^`_*[\]()<>!~]/,
+  ASCIIPunctuation: /[!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~\\]/,
+  // Newlines are excluded so that, when a paragraph spanning multiple source lines is parsed as
+  // one joined string, a soft line break (\n) terminates the current text run and can be handled
+  // explicitly as a line break rather than being swallowed into a default token.
+  NotTriggerChar: /[^`_*[\]()<>!~\n]/,
   Scheme: /[A-Za-z][A-Za-z0-9+.-]{1,31}/,
   Email: /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/, // From CommonMark spec
   HTMLOpenTag: /<HTMLTagName(?:HTMLAttribute)*\s*\/?>/,


### PR DESCRIPTION
## Summary

Fixes #166 — inline styles (bold, italic, strikethrough, ...) that span more than one source line were not detected, because inline parsing operated strictly one line at a time.

Lines that together form one paragraph-bearing block are now inline-parsed as a single unit (soft line breaks become newline markers). The resulting HTML is split back into one fragment per source line; any inline element still open at a line break is closed at the end of the line and re-opened at the start of the next, so:

- each line keeps its own well-formed block element, and
- each line's **text content is unchanged**, so cursor / column / selection mapping is unaffected.

This is covered for **paragraphs, multi-line blockquotes, and list items** (with wrapped / lazy-continuation lines).

## Changes

- **`src/grammar.ts`** — exclude `\n` from `NotTriggerChar` so a text run terminates at a soft line break.
- **`src/TinyMDE.ts`**
  - `processInlineStyles` emits a `\n` marker at soft line breaks.
  - `applyLineTypes` groups lines into inline-parsing units (`applyInlineGroup`): each line's inline content (the `$$N` portion of its replacement) is joined, parsed jointly, and re-split via `splitInlineHTMLByLine` (tag rebalancer); per-line markers (list bullets, blockquote `>`) are preserved via `replaceWithInline`.
  - **Continuation rules:** a plain paragraph line lazily continues any block; consecutive blockquote lines continue the same quote unless the content is blank (a paragraph break inside the quote); consecutive list markers each start a new item and do **not** join.
  - A per-element render signature (`dataset.mlSig`, hashing line types/replacements/captures) re-renders a group when a sibling line changes or the group's boundaries shift on a split/merge — the case the per-line dirty flag alone misses.

## Tests

- `jest/multiline-inline.test.js` (new): styles across 2–3 lines, the exact #166 example, nested-emphasis rebalancing, unclosed delimiters, text-content preservation; blockquotes (spanning, blank-line break, lazy continuation); lists (item wrap, ordered lists, and the negative case that two separate items must **not** merge); plus negative cases for blank line / heading boundaries.
- `jest/interaction.test.js`: live split (Enter) deactivates a spanning style on the now-standalone line; live merge (Backspace) activates one across the join.
- Updated one existing inline test that used two adjacent lines to test two *independent* cases (now one paragraph) — separated with a blank line.

All 184 tests pass on Chromium. **Firefox/WebKit were not run** in my environment (missing system libs); please run the full `npm run test` before merging.

## Scope / follow-ups

Code spans and links spanning lines remain out of scope (their regexes/parsers don't currently cross newlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
