### PR TITLE
fix: escape angle brackets in link destination marks

### DIFF
--- a/jest/multiline-inline.test.js
+++ b/jest/multiline-inline.test.js
@@ -147,3 +147,20 @@ test("emphasis does NOT span across two separate list items", async () => {
   expect(await editor.lineHTML(1)).not.toMatch(/<strong/);
   editor.destroy();
 });
+
+// Regression: angle-bracketed link destination in a multi-line group ------------------------
+
+// A link with an angle-bracketed destination (`[text](<dest>)`) emits literal `<`/`>` mark
+// characters. When such a line is part of a multi-line inline group, splitInlineHTMLByLine used to
+// mistake the raw `<` for an open HTML tag and leak a spurious `<` onto the following line (and add
+// another on every keystroke).
+test("an angle-bracketed link destination does not leak a '<' onto the next line", async () => {
+  const editor = await initTinyMDE("Some [inline](<link>)\nText");
+  // The link line keeps its exact source text.
+  expect(await editor.lineText(0)).toEqual("Some [inline](<link>)");
+  // The following line must be exactly "Text", not "<Text".
+  expect(await editor.lineText(1)).toEqual("Text");
+  // And the round-tripped content is unchanged.
+  expect(await editor.content()).toEqual("Some [inline](<link>)\nText");
+  editor.destroy();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4763,9 +4763,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001759",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
-      "integrity": "sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -1749,18 +1749,21 @@ export class Editor {
         linkDetails.push("");
       }
 
+      // Every literal mark fragment is HTML-escaped: linkDetails[0]/[2] hold the angle brackets of
+      // an `<...>` destination, so leaving them raw would inject a stray `<`/`>` into the output —
+      // which splitInlineHTMLByLine then mistakes for an HTML tag.
       return {
         output: `<span class="TMMark TMMark_${type}">${opener}</span><span class="${type}">${this.processInlineStyles(
           linkText
         )}</span><span class="TMMark TMMark_${type}">](${
-          linkDetails[0]
+          htmlescape(linkDetails[0])
         }</span><span class="${type}Destination">${
           htmlescape(linkDetails[1])
-        }</span><span class="TMMark TMMark_${type}">${linkDetails[2]}${
-          linkDetails[3]
-        }${linkDetails[4]}</span><span class="${type}Title">${
+        }</span><span class="TMMark TMMark_${type}">${htmlescape(linkDetails[2])}${
+          htmlescape(linkDetails[3])
+        }${htmlescape(linkDetails[4])}</span><span class="${type}Title">${
           htmlescape(linkDetails[5])
-        }</span><span class="TMMark TMMark_${type}">${linkDetails[6]})</span>`,
+        }</span><span class="TMMark TMMark_${type}">${htmlescape(linkDetails[6])})</span>`,
         charCount: currentOffset,
       };
     }

--- a/src/html/demo.html
+++ b/src/html/demo.html
@@ -56,14 +56,15 @@ And another [ref link][].
 A valid [link to a ref][ref] here.
 An invalid [ref link][nope].
 An [inline link](/inline) here.
-Some [inline](<links>) [inline](<link link> "title title") [inline](<link link> (title title)) [inline](  <link link>   'title \\' title') ss
+Some valid [inline](<links>) [inline](<link link> "title \" title") [inline](<link link> (title title)) [inline](  <link link>   'title \' title') ss
 [Inline](  /with invalid title text  ) here.
 [Inline]( </with (complex) dest>  (and title text) ) here.
 [Inline](<> "") link with empty delimiters
 [Inline]() link completely empty
 [Valid link](")))") here
 [Valid link](<)))>) here
-[Invalid](  ( ) here
+[Invalid](  ( ) here  
+[Invalid](<link> "title \\" here")
 This one [is *a](link) over* here, but not an emphasis.
 Here [the [inner](one) is] the valid link.
 An ![image [can](have) a](link) inside it.


### PR DESCRIPTION
## Problem

A regression introduced by multi-line inline formatting (#168, commit a4f976a). The text:

```
Some [inline](<link>)
Text
```

was parsed/output as:

```
Some [inline](<link>)
<Text
```

— a stray `<` leaked onto the following line, and another `<` was added on every keystroke.

## Root cause

The multi-line inline feature joins consecutive paragraph lines, inline-parses them as one unit, then splits the resulting HTML back per line with `splitInlineHTMLByLine()`. That splitter scans the HTML character-by-character and treats any `<` as the start of an HTML tag.

The inline-link renderer in `parseLinkOrImage` emitted the mark fragments of an angle-bracketed destination (`[text](<dest>)`) **without HTML-escaping** — `linkDetails[0]` holds the literal `<` and `linkDetails[2]` the literal `>`. On a single line browsers tolerated the malformed markup, but inside a multi-line group the splitter saw the raw `<`, mistook it for an unclosed tag, and re-emitted it at every soft line break.

## Fix

HTML-escape all literal mark fragments of the link output so no raw `<`/`>` reaches the HTML splitter.

## Testing

- Added a regression test in `jest/multiline-inline.test.js` reproducing the issue (committed before the fix). It failed across chromium/webkit/firefox with `Received: "<Text"` and passes after the fix.
- Full suite (555 tests) green.

Also includes two minor housekeeping commits: a demo-page fix and a browserslist DB update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)