### PR TITLE
feat: support GFM extended (non-delimited) autolinks

### DIFF
--- a/jest/extended-autolink.test.js
+++ b/jest/extended-autolink.test.js
@@ -1,0 +1,141 @@
+// Tests for GFM extended (non-delimited) autolinks: bare URLs, www links, email addresses and
+// mailto:/xmpp: links that are recognized without `<...>` delimiters.
+// See https://github.github.com/gfm/#autolinks-extension-
+//
+// Extended autolinks are rendered exactly like the content of an angle-bracketed autolink: the
+// matched text wrapped in a `TMAutolink` span (with no surrounding mark characters, since there
+// are no delimiters). The rendered line's text content therefore equals the source line.
+
+test("a bare http URL is recognized", async () => {
+  const editor = await initTinyMDE("Visit http://foo.bar/baz here");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("http://foo.bar/baz", "TMAutolink"));
+  expect(await editor.lineText(0)).toEqual("Visit http://foo.bar/baz here");
+  editor.destroy();
+});
+
+test("a bare https URL is recognized", async () => {
+  const editor = await initTinyMDE("https://example.com/a?b=c&d=e");
+  expect(await editor.lineHTML(0)).toMatch(
+    classTagRegExp("https://example.com/a?b=c&d=e", "TMAutolink")
+  );
+  editor.destroy();
+});
+
+test("a bare ftp URL is recognized", async () => {
+  const editor = await initTinyMDE("ftp://files.example.com/pub");
+  expect(await editor.lineHTML(0)).toMatch(
+    classTagRegExp("ftp://files.example.com/pub", "TMAutolink")
+  );
+  editor.destroy();
+});
+
+test("a www. link is recognized", async () => {
+  const editor = await initTinyMDE("See www.example.com for more");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com", "TMAutolink"));
+  editor.destroy();
+});
+
+test("a www. link with a path is recognized", async () => {
+  const editor = await initTinyMDE("www.example.com/path/to/page");
+  expect(await editor.lineHTML(0)).toMatch(
+    classTagRegExp("www.example.com/path/to/page", "TMAutolink")
+  );
+  editor.destroy();
+});
+
+test("a bare email address is recognized", async () => {
+  const editor = await initTinyMDE("Mail foo@example.com today");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("foo@example.com", "TMAutolink"));
+  editor.destroy();
+});
+
+test("a mailto: link is recognized", async () => {
+  const editor = await initTinyMDE("mailto:foo@example.com");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("mailto:foo@example.com", "TMAutolink"));
+  editor.destroy();
+});
+
+test("an xmpp: link with a resource is recognized", async () => {
+  const editor = await initTinyMDE("xmpp:foo@example.com/bar");
+  expect(await editor.lineHTML(0)).toMatch(
+    classTagRegExp("xmpp:foo@example.com/bar", "TMAutolink")
+  );
+  editor.destroy();
+});
+
+// Boundary rules --------------------------------------------------------------------------------
+
+test("an autolink is recognized at the start of a line", async () => {
+  const editor = await initTinyMDE("http://foo.bar/baz");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("http://foo.bar/baz", "TMAutolink"));
+  editor.destroy();
+});
+
+test("an autolink is recognized after an opening parenthesis", async () => {
+  const editor = await initTinyMDE("(www.example.com)");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com", "TMAutolink"));
+  editor.destroy();
+});
+
+test("a URL preceded by a non-boundary character is NOT an autolink", async () => {
+  const editor = await initTinyMDE("xhttp://foo.bar/baz");
+  expect(await editor.lineHTML(0)).not.toMatch("TMAutolink");
+  editor.destroy();
+});
+
+// Trailing punctuation / parentheses ------------------------------------------------------------
+
+test("trailing punctuation is excluded from the autolink", async () => {
+  const editor = await initTinyMDE("Go to www.example.com.");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com", "TMAutolink"));
+  // The trailing period must remain plain text on the line.
+  expect(await editor.lineText(0)).toEqual("Go to www.example.com.");
+  editor.destroy();
+});
+
+test("an unmatched trailing parenthesis is excluded", async () => {
+  const editor = await initTinyMDE("(see www.example.com/foo)");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com/foo", "TMAutolink"));
+  editor.destroy();
+});
+
+test("a balanced trailing parenthesis is kept inside the autolink", async () => {
+  const editor = await initTinyMDE("www.example.com/foo(bar)");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com/foo(bar)", "TMAutolink"));
+  editor.destroy();
+});
+
+// Negative cases --------------------------------------------------------------------------------
+
+test("a domain without a dot is NOT an autolink", async () => {
+  const editor = await initTinyMDE("http://localhost/foo");
+  expect(await editor.lineHTML(0)).not.toMatch("TMAutolink");
+  editor.destroy();
+});
+
+test("a space ends a bare URL autolink", async () => {
+  const editor = await initTinyMDE("www.example.com/foo bar");
+  expect(await editor.lineText(0)).toEqual("www.example.com/foo bar");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com/foo", "TMAutolink"));
+  expect(await editor.lineHTML(0)).not.toMatch(classTagRegExp("www.example.com/foo bar", "TMAutolink"));
+  editor.destroy();
+});
+
+test("extended autolinks do not interfere with inline links", async () => {
+  const editor = await initTinyMDE("[text](http://foo.bar/baz)");
+  // The link destination is rendered as a TMLinkDestination, not an autolink.
+  expect(await editor.lineHTML(0)).toMatch(/TMLinkDestination/);
+  expect(await editor.lineHTML(0)).not.toMatch("TMAutolink");
+  editor.destroy();
+});
+
+// Multi-line interaction ------------------------------------------------------------------------
+
+test("a bare URL on one line of a paragraph does not leak onto the next line", async () => {
+  const editor = await initTinyMDE("See www.example.com\nnext line");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("www.example.com", "TMAutolink"));
+  expect(await editor.lineText(0)).toEqual("See www.example.com");
+  expect(await editor.lineText(1)).toEqual("next line");
+  expect(await editor.content()).toEqual("See www.example.com\nnext line");
+  editor.destroy();
+});

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -1098,6 +1098,20 @@ export class Editor {
         }
       }
 
+      // Check for GFM extended (non-delimited) autolinks: bare URLs (www.…, http(s)://…, ftp://…),
+      // email addresses, and mailto:/xmpp: links. These are only recognized at the start of the
+      // string or immediately after whitespace or one of the delimiters `*`, `_`, `~`, `(`.
+      const precedingChar = offset > 0 ? originalString[offset - 1] : "";
+      if (precedingChar === "" || /[\s*_~(]/.test(precedingChar)) {
+        let autolink = this.parseAutolinkExtension(string);
+        if (autolink) {
+          processed = `${processed}${autolink.output}`;
+          string = string.substr(autolink.charCount);
+          offset += autolink.charCount;
+          continue outer;
+        }
+      }
+
       // Check for links / images
       let potentialLink = string.match(this.mergedInlineGrammar.linkOpen.regexp);
       let potentialImage = string.match(this.mergedInlineGrammar.imageOpen.regexp);
@@ -1435,6 +1449,117 @@ export class Editor {
         }
       }
     });
+  }
+
+  /**
+   * Attempts to parse a GFM extended (non-delimited) autolink at the start of `string`: a bare URL
+   * (`www.…`, `http://…`, `https://…`, `ftp://…`), an email address, or a `mailto:`/`xmpp:` link.
+   * The caller is responsible for the preceding-character boundary check. On success, returns the
+   * rendered HTML (the matched text wrapped in a `TMAutolink` span, exactly like the content of an
+   * angle-bracketed autolink) and the number of source characters consumed; otherwise `false`.
+   */
+  public parseAutolinkExtension(string: string): {output: string, charCount: number} | false {
+    const match = this.matchExtendedAutolink(string);
+    if (!match) return false;
+    return {
+      output: `<span class="TMAutolink">${htmlescape(match)}</span>`,
+      charCount: match.length,
+    };
+  }
+
+  /** Returns the longest extended-autolink substring at the start of `string`, or `false`. */
+  private matchExtendedAutolink(string: string): string | false {
+    // --- Bare URL / www autolink -----------------------------------------------------------------
+    // www. is treated as part of the domain; an explicit scheme is stripped before the domain.
+    const schemeCap = /^(?:https?|ftp):\/\//i.exec(string);
+    const isWww = /^www\./i.test(string);
+    if (schemeCap || isWww) {
+      const prefixLen = schemeCap ? schemeCap[0].length : 0;
+      const afterPrefix = string.substr(prefixLen);
+      // A valid domain is dot-separated segments of alphanumerics, `_` and `-`, with at least one
+      // dot and no underscore in the last two segments.
+      const domainCap = /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/.exec(afterPrefix);
+      if (domainCap && this.isValidAutolinkDomain(domainCap[0])) {
+        // After the domain, any run of non-space, non-`<` characters forms the path/query/fragment.
+        const pathCap = /^[^\s<]*/.exec(afterPrefix.substr(domainCap[0].length));
+        const link = string.substr(0, prefixLen + domainCap[0].length + (pathCap ? pathCap[0].length : 0));
+        const trimmed = this.trimAutolinkTrailing(link);
+        // Guard against trailing punctuation trimming having eaten into the domain.
+        if (trimmed.length >= prefixLen + domainCap[0].length) return trimmed;
+      }
+    }
+
+    // --- mailto: / xmpp: autolink ----------------------------------------------------------------
+    const protoCap = /^(?:mailto|xmpp):/i.exec(string);
+    if (protoCap) {
+      const emailCap = this.matchAutolinkEmail(string.substr(protoCap[0].length));
+      if (emailCap) {
+        // xmpp addresses may carry a `/resource` suffix.
+        let extra = "";
+        if (/^xmpp:/i.test(string)) {
+          const resCap = /^\/[a-zA-Z0-9@.\-_]+/.exec(
+            string.substr(protoCap[0].length + emailCap.length)
+          );
+          if (resCap) extra = resCap[0];
+        }
+        return protoCap[0] + emailCap + extra;
+      }
+    }
+
+    // --- Bare email autolink ---------------------------------------------------------------------
+    const email = this.matchAutolinkEmail(string);
+    if (email) return email;
+
+    return false;
+  }
+
+  /** GFM domain validity: at least one dot and no underscore in the last two segments. */
+  private isValidAutolinkDomain(domain: string): boolean {
+    const segments = domain.split(".");
+    if (segments.length < 2) return false;
+    return !segments.slice(-2).some((seg) => seg.indexOf("_") >= 0);
+  }
+
+  /** Matches a bare email address at the start of `string` per the GFM extension, or `false`. */
+  private matchAutolinkEmail(string: string): string | false {
+    // Local part: alphanumerics plus `.`, `-`, `_`, `+`. Domain: dot-separated labels of
+    // alphanumerics, `-` and `_`, with at least one dot and no `-`/`_` as the final character.
+    const cap = /^[a-zA-Z0-9.\-_+]+@[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/.exec(string);
+    if (!cap) return false;
+    let email = cap[0];
+    while (email.length && /[-_]$/.test(email)) email = email.substr(0, email.length - 1);
+    // Must still end in a complete TLD (i.e. retain a dot after the trimming).
+    if (!/\.[a-zA-Z0-9]+$/.test(email)) return false;
+    return email;
+  }
+
+  /**
+   * Strips trailing characters that GFM excludes from an autolink: the punctuation `?!.,:*_~`, and
+   * any unbalanced trailing `)` (more closing than opening parentheses in the link).
+   */
+  private trimAutolinkTrailing(link: string): string {
+    let end = link.length;
+    let changed = true;
+    while (changed && end > 0) {
+      changed = false;
+      const c = link[end - 1];
+      if ("?!.,:*_~".indexOf(c) >= 0) {
+        end--;
+        changed = true;
+      } else if (c === ")") {
+        let open = 0;
+        let close = 0;
+        for (let i = 0; i < end; i++) {
+          if (link[i] === "(") open++;
+          else if (link[i] === ")") close++;
+        }
+        if (close > open) {
+          end--;
+          changed = true;
+        }
+      }
+    }
+    return link.substr(0, end);
   }
 
   public parseLinkOrImage(originalString: string, isImage: boolean): {output: string, charCount: number} | false {


### PR DESCRIPTION
## Summary

Adds support for [GFM extended (non-delimited) autolinks](https://github.github.com/gfm/#autolinks-extension-) — URLs, www links, email addresses and `mailto:`/`xmpp:` links recognized **without** `<...>` delimiters.

They render exactly like the content of an angle-bracketed autolink (the matched text wrapped in a `TMAutolink` span), but with no surrounding mark characters since there are no delimiters — so each rendered line's text content still equals its source.

### Recognized forms
- Bare URLs: `http://…`, `https://…`, `ftp://…`
- `www.` links
- Bare email addresses
- `mailto:` / `xmpp:` links (with optional xmpp `/resource`)

### Spec rules implemented
- **Boundary rule** — autolinks only start at the beginning of a line or after whitespace / `*`, `_`, `~`, `(`
- **Valid-domain validation** — at least one dot, no underscores in the last two segments
- **Trailing-punctuation exclusion** (`?!.,:*_~`)
- **Unbalanced trailing-parenthesis trimming**

### Implementation note
The new `parseAutolinkExtension` check integrates into the existing inline tokenizer. Because the `default` rule advances one character at a time, the check gets a chance at every position; it is gated by an inexpensive preceding-character boundary test so it only does real work at valid start positions.

## Testing
New `jest/extended-autolink.test.js` with 18 cases covering each form, boundary rules, trailing punctuation/parentheses, negative cases (e.g. `http://localhost`, `xhttp://…`), no interference with inline links, and a multi-line non-leak case. All pass across chromium/webkit/firefox; full suite green at 609 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)