### PR TITLE
feat: GFM task list items with clickable checkboxes

### DIFF
--- a/jest/tasklist.test.js
+++ b/jest/tasklist.test.js
@@ -1,0 +1,138 @@
+// Tests for GFM task list items: list items whose content begins with a checkbox marker `[ ]`,
+// `[x]` or `[X]` followed by whitespace. See https://github.github.com/gfm/#task-list-items-
+//
+// Only the inner character (space / x / X) is rendered as a checkbox (a `TMCheckbox` span); the
+// brackets and separator stay as ordinary `TMMark` text. The line type stays TMUL/TMOL and the
+// rendered line's text content still equals the source, so the markdown round-trips and the cursor
+// navigates the marker normally. Clicking the checkbox toggles it.
+
+// Recognition --------------------------------------------------------------------------------
+
+test("unchecked task items are recognized in unordered lists", async () => {
+  const testCases = ["- [ ] item", "* [ ] item", "+ [ ] item", "   - [ ] item"];
+  for (let testCase of testCases) {
+    const editor = await initTinyMDE(testCase);
+    expect(await editor.lineType(0)).toMatch("TMUL");
+    expect(await editor.lineHTML(0)).toMatch(/class\s*=\s*["'][^"']*TMCheckbox_unchecked/);
+    editor.destroy();
+  }
+});
+
+test("checked task items are recognized (x and X)", async () => {
+  for (let testCase of ["- [x] item", "- [X] item"]) {
+    const editor = await initTinyMDE(testCase);
+    expect(await editor.lineType(0)).toMatch("TMUL");
+    expect(await editor.lineHTML(0)).toMatch(/class\s*=\s*["'][^"']*TMCheckbox_checked/);
+    editor.destroy();
+  }
+});
+
+test("task items are recognized in ordered lists", async () => {
+  for (let testCase of ["1. [ ] item", "1) [x] item"]) {
+    const editor = await initTinyMDE(testCase);
+    expect(await editor.lineType(0)).toMatch("TMOL");
+    expect(await editor.lineHTML(0)).toMatch(/TMCheckbox/);
+    editor.destroy();
+  }
+});
+
+test("the brackets remain present as TMMark text", async () => {
+  const editor = await initTinyMDE("- [ ] item");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("[", "TMMark_TMTask"));
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("]", "TMMark_TMTask"));
+  editor.destroy();
+});
+
+test("inline formatting inside a task item is parsed", async () => {
+  const editor = await initTinyMDE("- [ ] buy *milk*");
+  expect(await editor.lineHTML(0)).toMatch(classTagRegExp("milk", "TMEm", "em"));
+  editor.destroy();
+});
+
+test("an empty task item (no content) is recognized", async () => {
+  const editor = await initTinyMDE("- [ ]");
+  expect(await editor.lineType(0)).toMatch("TMUL");
+  expect(await editor.lineHTML(0)).toMatch(/TMCheckbox_unchecked/);
+  expect(await editor.content()).toEqual("- [ ]");
+  editor.destroy();
+});
+
+// Text content / round-trip invariant ---------------------------------------------------------
+
+test("rendered text content equals the source line", async () => {
+  for (let src of ["- [ ] item", "- [x] item", "1. [X] do it"]) {
+    const editor = await initTinyMDE(src);
+    expect(await editor.lineText(0)).toEqual(src);
+    expect(await editor.content()).toEqual(src);
+    editor.destroy();
+  }
+});
+
+// Negative cases -----------------------------------------------------------------------------
+
+test("a marker without a following separator is NOT a task item", async () => {
+  const editor = await initTinyMDE("- [x]done");
+  expect(await editor.lineType(0)).toMatch("TMUL");
+  expect(await editor.lineHTML(0)).not.toMatch("TMCheckbox");
+  editor.destroy();
+});
+
+test("a marker not at the start of the content is NOT a task item", async () => {
+  const editor = await initTinyMDE("- foo [ ] bar");
+  expect(await editor.lineHTML(0)).not.toMatch("TMCheckbox");
+  editor.destroy();
+});
+
+test("a link at the start of a list item is NOT treated as a checkbox", async () => {
+  const editor = await initTinyMDE("- [text](http://example.com)");
+  expect(await editor.lineHTML(0)).not.toMatch("TMCheckbox");
+  expect(await editor.lineHTML(0)).toMatch(/TMLinkDestination/);
+  editor.destroy();
+});
+
+// Multi-line continuation --------------------------------------------------------------------
+
+test("inline styles span a task item and its lazy continuation line", async () => {
+  const editor = await initTinyMDE("- [ ] a *b\nc* d");
+  expect(await editor.lineHTML(0)).toMatch(/<em[^>]*>b<\/em>/);
+  expect(await editor.lineHTML(1)).toMatch(/<em[^>]*>c<\/em>/);
+  // Only the leader line carries the checkbox.
+  expect(await editor.lineHTML(0)).toMatch(/TMCheckbox/);
+  expect(await editor.lineHTML(1)).not.toMatch("TMCheckbox");
+  expect(await editor.content()).toEqual("- [ ] a *b\nc* d");
+  editor.destroy();
+});
+
+// Click to toggle ----------------------------------------------------------------------------
+
+test("clicking an unchecked checkbox checks it", async () => {
+  const editor = await initTinyMDE("- [ ] item");
+  await editor.clickCheckbox(0);
+  expect(await editor.content()).toEqual("- [x] item");
+  expect(await editor.lineHTML(0)).toMatch(/TMCheckbox_checked/);
+  editor.destroy();
+});
+
+test("clicking a checked checkbox unchecks it", async () => {
+  const editor = await initTinyMDE("- [x] item");
+  await editor.clickCheckbox(0);
+  expect(await editor.content()).toEqual("- [ ] item");
+  expect(await editor.lineHTML(0)).toMatch(/TMCheckbox_unchecked/);
+  editor.destroy();
+});
+
+test("toggling a checkbox is undoable", async () => {
+  const editor = await initTinyMDE("- [ ] item");
+  await editor.clickCheckbox(0);
+  expect(await editor.content()).toEqual("- [x] item");
+  await editor.undo();
+  expect(await editor.content()).toEqual("- [ ] item");
+  editor.destroy();
+});
+
+test("toggling preserves the rest of the line", async () => {
+  const editor = await initTinyMDE("- [ ] a [link](http://x.com) b");
+  await editor.clickCheckbox(0);
+  expect(await editor.content()).toEqual("- [x] a [link](http://x.com) b");
+  editor.destroy();
+});

--- a/jest/util/test-helpers.js
+++ b/jest/util/test-helpers.js
@@ -35,6 +35,11 @@ global.initTinyMDE = async (content) => {
       newPage.$eval(`#tinymde > :first-child`, (el) => el.childNodes.length),
 
     content: async () => newPage.evaluate(() => tinyMDE.getContent()),
+    clickCheckbox: async (lineNum) =>
+      newPage.click(
+        `#tinymde > :first-child > :nth-child(${lineNum + 1}) .TMCheckbox`
+      ),
+    undo: async () => newPage.evaluate(() => tinyMDE.undo()),
     destroy: async () => newPage.close(),
   };
 };

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -261,6 +261,7 @@ export class Editor {
     this.e.addEventListener("focus", () => this.hasFocus = true );
     this.e.addEventListener("paste", (e) => this.handlePaste(e));
     this.e.addEventListener("drop", (e) => this.handleDrop(e));
+    this.e.addEventListener("click", (e) => this.handleClick(e));
     this.lineElements = this.e.childNodes;
   }
 
@@ -687,6 +688,41 @@ export class Editor {
         }
       }
 
+      // GFM task list item: a list item whose content begins with a checkbox marker `[ ]`, `[x]`
+      // or `[X]` followed by whitespace (or the end of the line). The brackets and separator stay
+      // as ordinary TMMark text; only the inner character is rendered as a checkbox (via CSS), so
+      // the line's text content still equals its source and the cursor navigates it normally.
+      if (lineType === "TMUL" || lineType === "TMOL") {
+        const content = lineCapture[2] !== undefined ? lineCapture[2] : "";
+        const task = /^(\[)([ xX])(\])(\s|$)([\s\S]*)$/.exec(content);
+        if (task) {
+          const checked = task[2] !== " "; // [x] / [X] are checked, [ ] is not
+          const bulletClass = lineType === "TMUL" ? "TMMark_TMUL" : "TMMark_TMOL";
+          const boxClass = checked
+            ? "TMCheckbox TMCheckbox_checked"
+            : "TMCheckbox TMCheckbox_unchecked";
+          // Synthetic capture: [full, bullet, "[", inner, "]", separator, inline content]. The
+          // inline content stays the last `$$N` group so inlineContentIndex()/applyInlineGroup()
+          // (and thus multi-line continuation) behave exactly as for a plain list item.
+          lineCapture = [
+            lineCapture[0],
+            lineCapture[1],
+            task[1],
+            task[2],
+            task[3],
+            task[4],
+            task[5],
+          ] as unknown as RegExpExecArray;
+          lineReplacement =
+            `<span class="TMMark ${bulletClass}">$1</span>` +
+            `<span class="TMMark TMMark_TMTask">$2</span>` +
+            `<span class="${boxClass}">$3</span>` +
+            `<span class="TMMark TMMark_TMTask">$4</span>` +
+            `<span class="TMMark TMMark_TMTask">$5</span>` +
+            `$$6`;
+        }
+      }
+
       if (this.lineTypes[lineNum] !== lineType) {
         this.lineTypes[lineNum] = lineType;
         this.lineDirty[lineNum] = true;
@@ -1051,6 +1087,41 @@ export class Editor {
   private handleDrop(event: DragEvent): void {
     event.preventDefault();
     this.fireDrop(event.dataTransfer!);
+  }
+
+  /**
+   * Toggles a task list checkbox when its rendered box is clicked. Only the single inner character
+   * of the marker (`[ ]` -> `[x]` and back) is changed; the edit is length-preserving, recorded in
+   * the undo history, and fires a `change` event, mirroring setCommandState's line-edit flow.
+   */
+  private handleClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    const box = target && target.closest ? (target.closest(".TMCheckbox") as HTMLElement | null) : null;
+    if (!box) return; // Not a checkbox click — let the default caret placement happen.
+
+    // Walk up to the line element (a direct child of the editor) to find its source row.
+    let lineEl: HTMLElement | null = box;
+    while (lineEl && lineEl.parentNode !== this.e) {
+      lineEl = lineEl.parentNode as HTMLElement | null;
+    }
+    if (!lineEl || lineEl.dataset.lineNum === undefined) return;
+    const row = parseInt(lineEl.dataset.lineNum, 10);
+    if (isNaN(row) || row < 0 || row >= this.lines.length) return;
+
+    const col = this.computeColumn(box, 0);
+    if (col === null) return;
+    const ch = this.lines[row].charAt(col);
+    if (ch !== " " && ch !== "x" && ch !== "X") return; // Defensive: not actually a checkbox char.
+
+    event.preventDefault();
+
+    if (!this.isRestoringHistory) this.pushHistory();
+    this.clearDirtyFlag();
+    const replacement = ch === " " ? "x" : " ";
+    this.lines[row] = this.lines[row].substr(0, col) + replacement + this.lines[row].substr(col + 1);
+    this.lineDirty[row] = true;
+    this.updateFormatting();
+    this.fireChange();
   }
 
   public processInlineStyles(originalString: string): string {

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -3,6 +3,7 @@ import {
   lineGrammar,
   punctuationLeading,
   punctuationTrailing,
+  editorRegExp,
   htmlescape,
   htmlBlockGrammar,
   commands,
@@ -201,7 +202,7 @@ export class Editor {
   }
 
   private handleUndoRedoKey(e: KeyboardEvent): void {
-    const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+    const isMac = editorRegExp.macPlatform.test(navigator.platform);
     const ctrl = isMac ? e.metaKey : e.ctrlKey;
     if (ctrl && !e.altKey) {
       if (e.key === "z" || e.key === "Z") {
@@ -269,7 +270,7 @@ export class Editor {
     while (this.e!.firstChild) {
       this.e!.removeChild(this.e!.firstChild);
     }
-    this.lines = content.split(/(?:\r\n|\r|\n)/);
+    this.lines = content.split(editorRegExp.lineSplit);
     this.lineDirty = [];
     for (let lineNum = 0; lineNum < this.lines.length; lineNum++) {
       let le = document.createElement("div");
@@ -316,7 +317,7 @@ export class Editor {
   }
 
   private replace(replacement: string, capture: RegExpExecArray): string {
-    return replacement.replace(/(\${1,2})([0-9])/g, (str, p1, p2) => {
+    return replacement.replace(editorRegExp.replacementPlaceholder, (str, p1, p2) => {
       if (p1 === "$") return htmlescape(capture[parseInt(p2)]);
       else
         return `<span class="TMInlineFormatted">${this.processInlineStyles(
@@ -376,7 +377,7 @@ export class Editor {
   private isBlankBlockquoteContent(lineNum: number): boolean {
     const cap = this.lineCaptures[lineNum];
     const content = cap && cap[2] !== undefined ? cap[2] : "";
-    return /^\s*$/.test(content);
+    return editorRegExp.blankContent.test(content);
   }
 
   private applyLine(lineNum: number): void {
@@ -457,7 +458,7 @@ export class Editor {
 
   /** Index of the inline-content placeholder (`$$N`) in a line replacement, or 0 if none. */
   private inlineContentIndex(replacement: string): number {
-    const m = /\$\$([0-9])/.exec(replacement);
+    const m = editorRegExp.inlineContentPlaceholder.exec(replacement);
     return m ? parseInt(m[1]) : 0;
   }
 
@@ -471,7 +472,7 @@ export class Editor {
     capture: RegExpExecArray,
     inlineFragment: string
   ): string {
-    return replacement.replace(/(\${1,2})([0-9])/g, (str, p1, p2) => {
+    return replacement.replace(editorRegExp.replacementPlaceholder, (str, p1, p2) => {
       if (p1 === "$") return htmlescape(capture[parseInt(p2)]);
       else return `<span class="TMInlineFormatted">${inlineFragment}</span>`;
     });
@@ -526,7 +527,7 @@ export class Editor {
   }
 
   private inlineTagName(openTag: string): string {
-    const m = /^<\s*([a-zA-Z][a-zA-Z0-9]*)/.exec(openTag);
+    const m = editorRegExp.inlineTagName.exec(openTag);
     return m ? m[1] : "span";
   }
 
@@ -694,7 +695,7 @@ export class Editor {
       // the line's text content still equals its source and the cursor navigates it normally.
       if (lineType === "TMUL" || lineType === "TMOL") {
         const content = lineCapture[2] !== undefined ? lineCapture[2] : "";
-        const task = /^(\[)([ xX])(\])(\s|$)([\s\S]*)$/.exec(content);
+        const task = editorRegExp.taskListItem.exec(content);
         if (task) {
           const checked = task[2] !== " "; // [x] / [X] are checked, [ ] is not
           const bulletClass = lineType === "TMUL" ? "TMMark_TMUL" : "TMMark_TMOL";
@@ -843,7 +844,7 @@ export class Editor {
       beginning = focus;
       end = anchor;
     }
-    let insertedLines = text.split(/(?:\r\n|\r|\n)/);
+    let insertedLines = text.split(editorRegExp.lineSplit);
     let lineBefore = this.lines[beginning.row].substr(0, beginning.col);
     let lineEnd = this.lines[end.row].substr(end.col);
     insertedLines[0] = lineBefore.concat(insertedLines[0]);
@@ -883,13 +884,13 @@ export class Editor {
              T extends 'selection' ? EventHandler<SelectionEvent> :
              T extends 'drop' ? EventHandler<DropEvent> : never
   ): void {
-    if (type.match(/^(?:change|input)$/i)) {
+    if (type.match(editorRegExp.changeEvent)) {
       this.listeners.change.push(listener as EventHandler<ChangeEvent>);
     }
-    if (type.match(/^(?:selection|selectionchange)$/i)) {
+    if (type.match(editorRegExp.selectionEvent)) {
       this.listeners.selection.push(listener as EventHandler<SelectionEvent>);
     }
-    if (type.match(/^(?:drop)$/i)) {
+    if (type.match(editorRegExp.dropEvent)) {
       this.listeners.drop.push(listener as EventHandler<DropEvent>);
     }
   }
@@ -1019,7 +1020,7 @@ export class Editor {
         if (capture) {
           if (capture[2]) {
             if (continuableType === "TMOL") {
-              capture[1] = capture[1].replace(/\d{1,9}/, (result) => {
+              capture[1] = capture[1].replace(editorRegExp.orderedListNumber, (result) => {
                 return (parseInt(result) + 1).toString();
               });
             }
@@ -1150,7 +1151,7 @@ export class Editor {
           if (cap) {
             string = string.substr(cap[0].length);
             offset += cap[0].length;
-            processed += this.mergedInlineGrammar[rule].replacement.replace(/\$([1-9])/g, (str, p1) => htmlescape(cap[p1]));
+            processed += this.mergedInlineGrammar[rule].replacement.replace(editorRegExp.inlineReplacementPlaceholder, (str, p1) => htmlescape(cap[p1]));
             continue outer;
           }
         }
@@ -1163,7 +1164,7 @@ export class Editor {
           if (cap) {
             string = string.substr(cap[0].length);
             offset += cap[0].length;
-            processed += this.mergedInlineGrammar[rule].replacement.replace(/\$([1-9])/g, (str, p1) => htmlescape(cap[p1]));
+            processed += this.mergedInlineGrammar[rule].replacement.replace(editorRegExp.inlineReplacementPlaceholder, (str, p1) => htmlescape(cap[p1]));
             continue outer;
           }
         }
@@ -1173,7 +1174,7 @@ export class Editor {
       // email addresses, and mailto:/xmpp: links. These are only recognized at the start of the
       // string or immediately after whitespace or one of the delimiters `*`, `_`, `~`, `(`.
       const precedingChar = offset > 0 ? originalString[offset - 1] : "";
-      if (precedingChar === "" || /[\s*_~(]/.test(precedingChar)) {
+      if (precedingChar === "" || editorRegExp.autolinkPrecedingChar.test(precedingChar)) {
         let autolink = this.parseAutolinkExtension(string);
         if (autolink) {
           processed = `${processed}${autolink.output}`;
@@ -1197,7 +1198,7 @@ export class Editor {
       }
 
       // Check for em / strong delimiters
-      let cap = /(^\*+)|(^_+)/.exec(string);
+      let cap = editorRegExp.emphasisDelimiter.exec(string);
       if (cap) {
         let delimCount = cap[0].length;
         const delimString = cap[0];
@@ -1210,8 +1211,8 @@ export class Editor {
 
         const punctuationFollows = following.match(punctuationLeading);
         const punctuationPrecedes = preceding.match(punctuationTrailing);
-        const whitespaceFollows = following.match(/^\s/);
-        const whitespacePrecedes = preceding.match(/\s$/);
+        const whitespaceFollows = following.match(editorRegExp.leadingWhitespace);
+        const whitespacePrecedes = preceding.match(editorRegExp.trailingWhitespace);
 
         let canOpen = !whitespaceFollows && (!punctuationFollows || !!whitespacePrecedes || !!punctuationPrecedes);
         let canClose = !whitespacePrecedes && (!punctuationPrecedes || !!whitespaceFollows || !!punctuationFollows);
@@ -1271,7 +1272,7 @@ export class Editor {
       }
 
       // Check for strikethrough delimiter
-      cap = /^~~/.exec(string);
+      cap = editorRegExp.strikethroughDelimiter.exec(string);
       if (cap) {
         let consumed = false;
         let stackPointer = stack.length - 1;
@@ -1311,7 +1312,7 @@ export class Editor {
       if (cap) {
         string = string.substr(cap[0].length);
         offset += cap[0].length;
-        processed += this.mergedInlineGrammar.default.replacement.replace(/\$([1-9])/g, (str, p1) => htmlescape(cap[p1]));
+        processed += this.mergedInlineGrammar.default.replacement.replace(editorRegExp.inlineReplacementPlaceholder, (str, p1) => htmlescape(cap[p1]));
         continue outer;
       }
       throw "Infinite loop!";
@@ -1542,17 +1543,17 @@ export class Editor {
   private matchExtendedAutolink(string: string): string | false {
     // --- Bare URL / www autolink -----------------------------------------------------------------
     // www. is treated as part of the domain; an explicit scheme is stripped before the domain.
-    const schemeCap = /^(?:https?|ftp):\/\//i.exec(string);
-    const isWww = /^www\./i.test(string);
+    const schemeCap = editorRegExp.autolinkScheme.exec(string);
+    const isWww = editorRegExp.autolinkWww.test(string);
     if (schemeCap || isWww) {
       const prefixLen = schemeCap ? schemeCap[0].length : 0;
       const afterPrefix = string.substr(prefixLen);
       // A valid domain is dot-separated segments of alphanumerics, `_` and `-`, with at least one
       // dot and no underscore in the last two segments.
-      const domainCap = /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/.exec(afterPrefix);
+      const domainCap = editorRegExp.autolinkDomain.exec(afterPrefix);
       if (domainCap && this.isValidAutolinkDomain(domainCap[0])) {
         // After the domain, any run of non-space, non-`<` characters forms the path/query/fragment.
-        const pathCap = /^[^\s<]*/.exec(afterPrefix.substr(domainCap[0].length));
+        const pathCap = editorRegExp.autolinkPath.exec(afterPrefix.substr(domainCap[0].length));
         const link = string.substr(0, prefixLen + domainCap[0].length + (pathCap ? pathCap[0].length : 0));
         const trimmed = this.trimAutolinkTrailing(link);
         // Guard against trailing punctuation trimming having eaten into the domain.
@@ -1561,14 +1562,14 @@ export class Editor {
     }
 
     // --- mailto: / xmpp: autolink ----------------------------------------------------------------
-    const protoCap = /^(?:mailto|xmpp):/i.exec(string);
+    const protoCap = editorRegExp.autolinkProtocol.exec(string);
     if (protoCap) {
       const emailCap = this.matchAutolinkEmail(string.substr(protoCap[0].length));
       if (emailCap) {
         // xmpp addresses may carry a `/resource` suffix.
         let extra = "";
-        if (/^xmpp:/i.test(string)) {
-          const resCap = /^\/[a-zA-Z0-9@.\-_]+/.exec(
+        if (editorRegExp.autolinkXmpp.test(string)) {
+          const resCap = editorRegExp.autolinkXmppResource.exec(
             string.substr(protoCap[0].length + emailCap.length)
           );
           if (resCap) extra = resCap[0];
@@ -1595,12 +1596,12 @@ export class Editor {
   private matchAutolinkEmail(string: string): string | false {
     // Local part: alphanumerics plus `.`, `-`, `_`, `+`. Domain: dot-separated labels of
     // alphanumerics, `-` and `_`, with at least one dot and no `-`/`_` as the final character.
-    const cap = /^[a-zA-Z0-9.\-_+]+@[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/.exec(string);
+    const cap = editorRegExp.autolinkEmail.exec(string);
     if (!cap) return false;
     let email = cap[0];
-    while (email.length && /[-_]$/.test(email)) email = email.substr(0, email.length - 1);
+    while (email.length && editorRegExp.emailTrailingChar.test(email)) email = email.substr(0, email.length - 1);
     // Must still end in a complete TLD (i.e. retain a dot after the trimming).
-    if (!/\.[a-zA-Z0-9]+$/.test(email)) return false;
+    if (!editorRegExp.emailTld.test(email)) return false;
     return email;
   }
 
@@ -1681,7 +1682,7 @@ export class Editor {
       }
 
       // Check for closing bracket
-      if (string.match(/^\]/)) {
+      if (string.match(editorRegExp.linkClosingBracket)) {
         bracketLevel--;
         if (bracketLevel === 0) {
           linkText = originalString.substr(textOffset, currentOffset - textOffset);
@@ -1727,7 +1728,7 @@ export class Editor {
         let string = originalString.substr(currentOffset);
 
         // Process whitespace
-        let cap = /^\s+/.exec(string);
+        let cap = editorRegExp.leadingWhitespaceRun.exec(string);
         if (cap) {
           switch (linkDetails.length) {
             case 0:
@@ -1737,7 +1738,7 @@ export class Editor {
               linkDetails.push(cap[0]);
               break;
             case 2:
-              if (linkDetails[0].match(/</)) {
+              if (linkDetails[0].match(editorRegExp.containsOpenAngle)) {
                 linkDetails[1] = linkDetails[1].concat(cap[0]);
               } else {
                 if (parenthesisLevel !== 1) return false;
@@ -1794,7 +1795,7 @@ export class Editor {
         }
 
         // Process opening angle bracket
-        if (linkDetails.length < 2 && string.match(/^</)) {
+        if (linkDetails.length < 2 && string.match(editorRegExp.openingAngle)) {
           if (linkDetails.length === 0) linkDetails.push("");
           linkDetails[0] = linkDetails[0].concat("<");
           currentOffset++;
@@ -1802,7 +1803,7 @@ export class Editor {
         }
 
         // Process closing angle bracket
-        if ((linkDetails.length === 1 || linkDetails.length === 2) && string.match(/^>/)) {
+        if ((linkDetails.length === 1 || linkDetails.length === 2) && string.match(editorRegExp.closingAngle)) {
           if (linkDetails.length === 1) linkDetails.push("");
           linkDetails.push(">");
           currentOffset++;
@@ -1810,7 +1811,7 @@ export class Editor {
         }
 
         // Process non-parenthesis delimiter for title
-        cap = /^["']/.exec(string);
+        cap = editorRegExp.titleQuote.exec(string);
         if (cap && (linkDetails.length === 0 || linkDetails.length === 1 || linkDetails.length === 4)) {
           while (linkDetails.length < 4) linkDetails.push("");
           linkDetails.push(cap[0]);
@@ -1826,7 +1827,7 @@ export class Editor {
         }
 
         // Process opening parenthesis
-        if (string.match(/^\(/)) {
+        if (string.match(editorRegExp.openingParen)) {
           switch (linkDetails.length) {
             case 0:
               linkDetails.push("");
@@ -1834,7 +1835,7 @@ export class Editor {
               linkDetails.push("");
             case 2:
               linkDetails[1] = linkDetails[1].concat("(");
-              if (!linkDetails[0].match(/<$/)) parenthesisLevel++;
+              if (!linkDetails[0].match(editorRegExp.endsWithOpenAngle)) parenthesisLevel++;
               break;
             case 3:
               linkDetails.push("");
@@ -1855,10 +1856,10 @@ export class Editor {
         }
 
         // Process closing parenthesis
-        if (string.match(/^\)/)) {
+        if (string.match(editorRegExp.closingParen)) {
           if (linkDetails.length <= 2) {
             while (linkDetails.length < 2) linkDetails.push("");
-            if (!linkDetails[0].match(/<$/)) parenthesisLevel--;
+            if (!linkDetails[0].match(editorRegExp.endsWithOpenAngle)) parenthesisLevel--;
             if (parenthesisLevel > 0) {
               linkDetails[1] = linkDetails[1].concat(")");
             }
@@ -1883,7 +1884,7 @@ export class Editor {
         }
 
         // Any old character
-        cap = /^./.exec(string);
+        cap = editorRegExp.anyChar.exec(string);
         if (cap) {
           switch (linkDetails.length) {
             case 0:
@@ -2118,7 +2119,7 @@ export class Editor {
 
         let match = this.lines[focus!.row]
           .substr(startCol, endCol - startCol)
-          .match(/^(?<leading>\s*).*\S(?<trailing>\s*)$/);
+          .match(editorRegExp.surroundingWhitespace);
         if (match) {
           startCol += match.groups!.leading.length;
           endCol -= match.groups!.trailing.length;

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -99,42 +99,46 @@
 /* Task list checkbox: only the inner character (space/x/X) of `[ ]` / `[x]` is rendered as a drawn
    checkbox. The character stays in the DOM as real, navigable text (its glyph is just hidden), so
    the line's text content still equals its source. The surrounding `[` `]` keep the .TMMark style. */
+
+.TMMark_TMTask {
+  color: #e0e0e0;
+}
+
 .TMCheckbox {
   position: relative;
   color: transparent;
   caret-color: #000000;
   cursor: pointer;
+  font-family: monospace;
 }
 
 .TMCheckbox::before {
   content: "";
   position: absolute;
   left: 50%;
-  top: 0.15em;
-  transform: translateX(-50%);
+  top: 50%;
+  transform: translateX(-50%) translateY(-50%);
   width: 0.85em;
   height: 0.85em;
-  border: 1.5px solid #808080;
-  border-radius: 3px;
+  border: 1px solid #c0c0c0;
   box-sizing: border-box;
+  border-radius: 2px;
   pointer-events: none;
 }
 
 .TMCheckbox_checked::before {
   border-color: #2aa775;
-  background: #2aa775;
 }
 
 .TMCheckbox_checked::after {
-  content: "";
+  content: "✓";
+  color: #2aa775;
   position: absolute;
+  top: 50%;
   left: 50%;
-  top: 0.2em;
-  width: 0.2em;
-  height: 0.45em;
-  border: solid #ffffff;
-  border-width: 0 2px 2px 0;
-  transform: translateX(-60%) rotate(45deg);
+  transform: translateX(-50%) translateY(-50%);
+  text-align: center;
+  vertical-align: top;
   box-sizing: border-box;
   pointer-events: none;
 }

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -96,6 +96,49 @@
   color:#ff8080;
 }
 
+/* Task list checkbox: only the inner character (space/x/X) of `[ ]` / `[x]` is rendered as a drawn
+   checkbox. The character stays in the DOM as real, navigable text (its glyph is just hidden), so
+   the line's text content still equals its source. The surrounding `[` `]` keep the .TMMark style. */
+.TMCheckbox {
+  position: relative;
+  color: transparent;
+  caret-color: #000000;
+  cursor: pointer;
+}
+
+.TMCheckbox::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0.15em;
+  transform: translateX(-50%);
+  width: 0.85em;
+  height: 0.85em;
+  border: 1.5px solid #808080;
+  border-radius: 3px;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.TMCheckbox_checked::before {
+  border-color: #2aa775;
+  background: #2aa775;
+}
+
+.TMCheckbox_checked::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0.2em;
+  width: 0.2em;
+  height: 0.45em;
+  border: solid #ffffff;
+  border-width: 0 2px 2px 0;
+  transform: translateX(-60%) rotate(45deg);
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
 .TMImage {
   text-decoration: underline;
   text-decoration-color: #00ff00;

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -64,9 +64,73 @@ export const punctuationLeading = new RegExp(/^(?:[!"#$%&'()*+,\-./:;<=>?@[\]\\^
 export const punctuationTrailing = new RegExp(/(?:[!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDF3C-\uDF3E]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B])$/);
 
 /**
- * This is CommonMark's block grammar, but we're ignoring nested blocks here.  
- */ 
-export const lineGrammar: Record<string, GrammarRule> = { 
+ * Standalone regular expressions used by the editor logic (TinyMDE.ts) that aren't part of the
+ * block / inline grammar tables above. Centralized here so every pattern the editor relies on lives
+ * in one place. Patterns flagged `g` are only ever used with String.prototype.replace(), which
+ * resets lastIndex, so sharing a single instance across call sites is safe.
+ */
+export const editorRegExp: Record<string, RegExp> = {
+  // Platform detection and line splitting.
+  macPlatform: /Mac|iPod|iPhone|iPad/,
+  lineSplit: /(?:\r\n|\r|\n)/,
+
+  // Replacement-template placeholder substitution.
+  replacementPlaceholder: /(\${1,2})([0-9])/g, // $N (literal) or $$N (inline content)
+  inlineContentPlaceholder: /\$\$([0-9])/, // locate the $$N inline-content placeholder
+  inlineReplacementPlaceholder: /\$([1-9])/g, // single-$ placeholder in merged inline grammar
+
+  // Blank / whitespace helpers.
+  blankContent: /^\s*$/,
+  leadingWhitespace: /^\s/,
+  trailingWhitespace: /\s$/,
+  leadingWhitespaceRun: /^\s+/,
+  surroundingWhitespace: /^(?<leading>\s*).*\S(?<trailing>\s*)$/,
+
+  // List / task list items.
+  taskListItem: /^(\[)([ xX])(\])(\s|$)([\s\S]*)$/,
+  orderedListNumber: /\d{1,9}/,
+
+  // Opening tag name of an inline HTML element.
+  inlineTagName: /^<\s*([a-zA-Z][a-zA-Z0-9]*)/,
+
+  // Event type matching (addEventListener).
+  changeEvent: /^(?:change|input)$/i,
+  selectionEvent: /^(?:selection|selectionchange)$/i,
+  dropEvent: /^(?:drop)$/i,
+
+  // Inline emphasis / strikethrough delimiters and the extended-autolink boundary.
+  autolinkPrecedingChar: /[\s*_~(]/,
+  emphasisDelimiter: /(^\*+)|(^_+)/,
+  strikethroughDelimiter: /^~~/,
+
+  // GFM extended (non-delimited) autolinks.
+  autolinkScheme: /^(?:https?|ftp):\/\//i,
+  autolinkWww: /^www\./i,
+  autolinkDomain: /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/,
+  autolinkPath: /^[^\s<]*/,
+  autolinkProtocol: /^(?:mailto|xmpp):/i,
+  autolinkXmpp: /^xmpp:/i,
+  autolinkXmppResource: /^\/[a-zA-Z0-9@.\-_]+/,
+  autolinkEmail: /^[a-zA-Z0-9.\-_+]+@[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+/,
+  emailTrailingChar: /[-_]$/,
+  emailTld: /\.[a-zA-Z0-9]+$/,
+
+  // Link / image destination parser (character-by-character scanning).
+  linkClosingBracket: /^\]/,
+  openingAngle: /^</,
+  closingAngle: /^>/,
+  titleQuote: /^["']/,
+  openingParen: /^\(/,
+  closingParen: /^\)/,
+  endsWithOpenAngle: /<$/,
+  containsOpenAngle: /</,
+  anyChar: /^./,
+};
+
+/**
+ * This is CommonMark's block grammar, but we're ignoring nested blocks here.
+ */
+export const lineGrammar: Record<string, GrammarRule> = {
   TMH1: { 
     regexp: /^( {0,3}#\s)(.*?)((?:\s+#+\s*)?)$/, 
     replacement: '<span class="TMMark TMMark_TMH1">$1</span>$$2<span class="TMMark TMMark_TMH1">$3</span>'

--- a/src/html/demo.html
+++ b/src/html/demo.html
@@ -100,7 +100,11 @@ block
 - 
 
 1) OL
-2) OL</textarea>
+2) OL
+
+- [ ] Task list item (click the box to toggle)
+- [x] Completed task with *inline* formatting
+1. [ ] Ordered task item</textarea>
     </div>
     <div id="status" style="text-align:right">- : -</div>
     <script>

--- a/src/html/demo.html
+++ b/src/html/demo.html
@@ -15,6 +15,9 @@
 [ref]: https://www.jefago.com
 [ref link]: </this has spaces> "and a title"
 
+- [ ] Task list item (click the box to toggle)
+- [x] Completed task with *inline* formatting
+
 
 Some <html> </tags> right here
 <html a="b" >


### PR DESCRIPTION
Closes #109.

## Summary

Adds support for [GFM task list items](https://github.github.com/gfm/#task-list-items-): list items whose content begins with a checkbox marker `[ ]`, `[x]`, or `[X]` followed by whitespace are rendered with a clickable checkbox. Works for both unordered (`- [ ]`) and ordered (`1. [ ]`) lists.

## The design challenge

TinyMDE is a source editor that maintains a key invariant: **each line element's `textContent` must equal its source line text**. Cursor mapping (`computeColumn`/`computeNodeAndOffset`) and content reconstruction (`updateLineContents`, which does `this.lines[line] = e.textContent`) all depend on it. A native `<input type="checkbox">` has zero `textContent` and would break cursor positions, navigation, and `getContent()` round-tripping.

## The approach

Keep the literal `[`, the inner char (space/`x`/`X`), `]`, and the separator all as **real, navigable text** in the DOM. Render `[` and `]` as ordinary `TMMark` spans (like every other mark), and render **only the single inner character** as a CSS-drawn checkbox (`color: transparent` + a drawn box/checkmark). 

This preserves the invariant completely — **zero changes** to `computeColumn`, `computeNodeAndOffset`, `updateLineContents`, `getContent`, undo/redo, or inline parsing. Arrow keys/backspace navigate the marker normally, and the markdown round-trips unchanged.

- **Detection** is done dynamically in `updateLineTypes()`, reusing the existing runtime replacement-building pattern (fenced code / HTML blocks). The line type stays `TMUL`/`TMOL` and the checked state lives in the checkbox span's class, so multi-line list grouping and inline parsing are unaffected.
- **Click-to-toggle**: a `click` listener toggles the source char (`[ ]` ↔ `[x]`), recorded in the undo history and firing a `change` event — the same flow as `setCommandState`. The edit is length-preserving, so selection stays valid.

## Testing

New `jest/tasklist.test.js` (15 cases): recognition for unordered/ordered & checked/unchecked, brackets preserved as `TMMark` text, inline formatting inside tasks, empty tasks, `textContent`/`getContent` round-trip invariant, negatives (no separator, marker not at start, links not misdetected), multi-line continuation, and click-toggle + undo + content preservation. Helpers `clickCheckbox()`/`undo()` added to `test-helpers.js`.

All pass across chromium/webkit/firefox; full suite green at 654 tests (was 609). Demo updated with task-list examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)