### PR TITLE
ci: fix Playwright browser install hang under npm 11 min-release-age

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -19,8 +19,16 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      # Call the local Playwright binary directly rather than via `npx`, matching release.yml and
+      # avoiding any npm/registry resolution (see the note there re: `.npmrc` min-release-age).
       - name: Install playwright browsers
-        run: npx playwright install --with-deps
+        run: ./node_modules/.bin/playwright install --with-deps
 
       - name: Build
         run: npm run build --if-present

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,19 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      # Call the Playwright binary installed by `npm ci` directly rather than via `npx`. Under
+      # npm 11 (Node 24) the repo's `.npmrc` `min-release-age` makes `npx`/`npm exec` perform a
+      # registry resolution that can stall on a confirmation prompt in non-interactive CI; invoking
+      # the local binary avoids npm/registry involvement entirely (the browser binaries come from
+      # Playwright's own CDN, so the supply-chain control offers nothing here anyway).
       - name: Install playwright browsers
-        run: npx playwright install --with-deps
+        run: ./node_modules/.bin/playwright install --with-deps
 
       - name: Build
         run: npm run build --if-present


### PR DESCRIPTION
## Problem

The **Release** workflow hangs on the *Install playwright browsers* step. The last successful release was [v0.2.28 on 2026-05-14](https://github.com/jefago/tiny-markdown-editor/actions/runs/25849455794/workflow).

## Root cause

Timeline:

| Date | Event |
|---|---|
| 2026-05-09 | release.yml moved to Node 24 |
| **2026-05-14** | **Last green release** (v0.2.28) — already on Node 24, `.npmrc` did not exist yet |
| 2026-05-22 | `.npmrc` adds `min-release-age=7` |
| now | First release since → hangs |

The Node 24 bump was already in place and green, so it isn't the cause. The only change to the release pipeline since the last green run is `.npmrc`'s `min-release-age=7`, and the workflow simply hadn't run since it was added.

`min-release-age` requires **npm 11.10+**:
- Release runs on **Node 24 → npm 11**, which honors it. `npx playwright install` is `npm exec`, which does a registry resolution that can stall on a non-interactive confirmation prompt → hang.
- PR tests run on **Node 22 → npm 10**, which silently ignores the key → they stayed green, masking the issue.

## Fix

- Call the Playwright binary that `npm ci` already installed **directly** (`./node_modules/.bin/playwright install --with-deps`) instead of through `npx`, so no npm/registry resolution happens. Browser binaries come from Playwright's own CDN, so `min-release-age` adds no security value here.
- `npm ci` keeps honoring `min-release-age` — the supply-chain control is preserved where it matters.
- Cache `~/.cache/ms-playwright` to skip the ~400 MB browser download on cache hits.

Applied to both `release.yml` and `pr-tests.yml` for consistency. Node versions left unchanged (24 is needed for OIDC publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)