### PR TITLE
fix(tests): wait for TinyMDE to be defined after page navigation

### DIFF
--- a/jest/commandbar.test.js
+++ b/jest/commandbar.test.js
@@ -1,5 +1,6 @@
 beforeEach(async () => {
   await page.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(page);
 });
 
 test('Basic command bar setup works', async () => {

--- a/jest/custom-grammar.test.js
+++ b/jest/custom-grammar.test.js
@@ -1,6 +1,7 @@
 const initTinyMDEWithCustomGrammar = async (content, customGrammar) => {
   const newPage = await global.context.newPage();
   await newPage.goto(global.PATH, { waitUntil: "load" });
+  await global.waitForTinyMDE(newPage);
   
   // Escape content for JavaScript string
   content = content

--- a/jest/interaction.test.js
+++ b/jest/interaction.test.js
@@ -1,5 +1,6 @@
 beforeEach(async () => {
   await page.goto(PATH, { waitUntil: "load" });
+  await global.waitForTinyMDE(page);
 });
 
 test("Bulleted list is continued when pressing enter", async () => {

--- a/jest/setup.test.js
+++ b/jest/setup.test.js
@@ -2,6 +2,7 @@
 test('sets up correctly when passed an ID', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({element: 'tinymde'});
@@ -13,6 +14,7 @@ test('sets up correctly when passed an ID', async () => {
 test('sets up correctly when passed an element', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({element: document.getElementById('tinymde')});
@@ -24,6 +26,7 @@ test('sets up correctly when passed an element', async () => {
 test('sets up correctly when passed a textarea ID as element', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
   await newPage.$eval('#tinymde', el => el.innerHTML = '<textarea id="txt"></textarea>');
   await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({element: document.getElementById('txt')});
@@ -37,6 +40,7 @@ test('sets up correctly when passed a textarea ID as element', async () => {
 test('sets up correctly when passed an element AND a textarea', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
   await newPage.$eval('#tinymde', el => el.innerHTML = '<textarea id="txt"></textarea>');
 
   await newPage.evaluate(() => {
@@ -52,6 +56,7 @@ test('sets up correctly when passed an element AND a textarea', async () => {
 test('Content can be passed to constructor', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const content = '# XXXA\nXXXB *XXXC*';
 
@@ -67,6 +72,7 @@ test('Content can be passed to constructor', async () => {
 test('Content can be passed from textarea', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const content = '# XXXA';
 
@@ -85,6 +91,7 @@ test('Content can be passed from textarea', async () => {
 test('Content passed in constructor has precedence over textarea content', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const textareaContent = '# XXXA';
   const constructorContent = '# XXXB';
@@ -106,6 +113,7 @@ test('Content passed in constructor has precedence over textarea content', async
 test('Content can be set using setContent()', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const content = '# XXXA\nXXXB *XXXC*';
 
@@ -123,6 +131,7 @@ test('Content can be set using setContent()', async () => {
 test('Linked textarea updated on setContent()', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const content = '# XXXA\nXXXB *XXXC*';
 
@@ -147,6 +156,7 @@ test('Linked textarea updated on setContent()', async () => {
 test('Change event listeners called on setContent()', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load'});
+  await global.waitForTinyMDE(newPage);
 
   const content = '# XXXA\nXXXB *XXXC*';
 
@@ -167,6 +177,7 @@ test('Change event listeners called on setContent()', async () => {
 test('Placeholder is not shown for Empty content', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const content = '';
 
@@ -185,6 +196,7 @@ test('Placeholder is not shown for Empty content', async () => {
 test('Placeholder from props is set on editor element', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const result = await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({
@@ -207,6 +219,7 @@ test('Placeholder from props is set on editor element', async () => {
 test('Placeholder from textarea is picked up', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const result = await newPage.evaluate(() => {
     const textarea = document.createElement('textarea');
@@ -228,6 +241,7 @@ test('Placeholder from textarea is picked up', async () => {
 test('Placeholder prop takes precedence over textarea placeholder', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const result = await newPage.evaluate(() => {
     const textarea = document.createElement('textarea');
@@ -249,6 +263,7 @@ test('Placeholder prop takes precedence over textarea placeholder', async () => 
 test('Placeholder hidden when content exists', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const hasEmptyClass = await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({
@@ -267,6 +282,7 @@ test('Placeholder hidden when content exists', async () => {
 test('Placeholder reappears when content is cleared', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const result = await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({
@@ -289,6 +305,7 @@ test('Placeholder reappears when content is cleared', async () => {
 test('No placeholder attribute when placeholder not specified', async () => {
   const newPage = await global.context.newPage();
   await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
 
   const result = await newPage.evaluate(() => {
     const tinyMDE = new TinyMDE.Editor({

--- a/jest/tasklist-command.test.js
+++ b/jest/tasklist-command.test.js
@@ -3,6 +3,7 @@
 
 beforeEach(async () => {
   await page.goto(PATH, { waitUntil: "load" });
+  await global.waitForTinyMDE(page);
 });
 
 const initEditor = async (content) => {

--- a/jest/util/test-helpers.js
+++ b/jest/util/test-helpers.js
@@ -2,9 +2,14 @@ const { PORT } = require("./config");
 
 global.PATH = `http://localhost:${PORT}/blank.html`;
 
+global.waitForTinyMDE = async (page) => {
+  await page.waitForFunction(() => typeof TinyMDE !== 'undefined', { timeout: 10000 });
+};
+
 global.initTinyMDE = async (content) => {
   const newPage = await global.context.newPage();
   await newPage.goto(global.PATH, { waitUntil: "load" });
+  await global.waitForTinyMDE(newPage);
   content = content
     .replace(/(['"\\])/g, "\\$1")
     .replace(/\n/g, "\\n")


### PR DESCRIPTION
## Summary

- Fixes random Firefox test failures where `TinyMDE is not defined` errors were reported
- Root cause: when all 3 browser projects (Firefox, Chromium, Webkit) run concurrently, `tiny-mde.js` occasionally fails to load in Firefox due to transient server contention; browsers still fire the `load` event even when a script fails to load, so `waitUntil: 'load'` resolved before TinyMDE was actually available
- Adds a `global.waitForTinyMDE(page)` helper that uses Playwright's `waitForFunction` to explicitly wait for `TinyMDE` to appear in the browser global scope
- Applied the check after every `page.goto()` call across all 6 test files

## Test plan

- [x] Full test suite passes (`684 passed, 684 total`) across all 3 browsers
- [x] `setup.test.js` (the file where all 17 Firefox failures were observed) now consistently passes when run with all 3 projects concurrently

🤖 Generated with [Claude Code](https://claude.ai/claude-code)