### PR TITLE
Strip style attributes from SVG icons to avoid CSP violations

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -119,6 +119,16 @@ const watch = () => {
   gulp.watch("./src/**/*.html", html);
 };
 
+// Inkscape (and other editors) often leave inline `style="..."` attributes and
+// `<style>` blocks in exported SVGs. These trigger Content-Security-Policy
+// violations when the icons are injected into the DOM, so strip them out when
+// generating svg.ts. The svg-style.test.js test guards against regressions.
+const stripSvgStyles = (svg) =>
+  svg
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/\s+style\s*=\s*"[^"]*"/gi, "")
+    .replace(/\s+style\s*=\s*'[^']*'/gi, "");
+
 const svg = () => {
   const dirEntries = fs.readdirSync(path.join(".", "src", "svg"), {
     withFileTypes: true,
@@ -131,9 +141,9 @@ const svg = () => {
         readfile(path.join(".", "src", "svg", fn), { encoding: "utf8" }).then(
           (buffer) => {
             // console.log(entry.name + ': ' + buffer.toString().replace(/([`\$\\])/g, '\\$1'));
-            return `${fn.replace(/^(.*)\.svg$/i, "$1")}: \`${buffer
-              .toString()
-              .replace(/([`$\\])/g, "\\$1")}\``;
+            return `${fn.replace(/^(.*)\.svg$/i, "$1")}: \`${stripSvgStyles(
+              buffer.toString()
+            ).replace(/([`$\\])/g, "\\$1")}\``;
           }
         )
       );

--- a/jest/svg-style.test.js
+++ b/jest/svg-style.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+// Inline `style="..."` attributes and `<style>` blocks in the icon SVGs trigger
+// Content-Security-Policy violations when the icons are injected into the DOM.
+// The `svg` task in gulpfile.mjs strips these out when generating svg.ts; this
+// test guards against them sneaking back in (e.g. via a freshly exported
+// Inkscape SVG that wasn't run through the build).
+
+const svgDir = path.join(__dirname, '..', 'src', 'svg');
+
+test('generated svg.ts contains no inline style attributes or <style> blocks', () => {
+  const generated = fs.readFileSync(path.join(svgDir, 'svg.ts'), 'utf8');
+
+  expect(generated).not.toMatch(/\sstyle\s*=/i);
+  expect(generated).not.toMatch(/<style[\s>]/i);
+});


### PR DESCRIPTION
## Problem

Icons generated in Inkscape are exported with leftover inline `style="..."` attributes (and sometimes `<style>` blocks). When these icons are injected into the DOM, they trigger Content-Security-Policy violations.

## Changes

- **`gulpfile.mjs`** — the `svg` task now runs each SVG through a new `stripSvgStyles()` helper before serializing into `src/svg/svg.ts`. It removes `<style>…</style>` blocks, `style="…"` attributes, and `style='…'` attributes, so the generated icon strings are CSP-clean regardless of what the source SVG contains.
- **`jest/svg-style.test.js`** — new test that reads the generated `svg.ts` (the artifact actually injected into the DOM) and fails if any inline `style=` attribute or `<style>` block is present. This guards against regressions and against a freshly exported Inkscape SVG slipping through.

## Verification

- Added a temporary Inkscape-style SVG containing a `<style>` block plus both `style="…"` and `style='…'` attributes; confirmed all three forms were stripped from the generated output.
- Confirmed the test passes on the clean output and fails when a style attribute is injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)