### PR TITLE
fix: let the editor background cover overflowing content (#182)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `npm run dev` - Start development mode with file watching and live reload
 - `npm run build` - Build production assets (JS, CSS, HTML)
-- `npm run test` - Run Jest tests with Puppeteer (browser-based testing)
-- `npm run prepublishOnly` - Full build, test, and transpile pipeline for publishing
+- `npm run test` - Build, then run the Jest + Playwright tests in all three browsers
+- `npm run test:chromium` / `test:firefox` / `test:webkit` - Same, for a single browser
+- `npm run typecheck` - Type-check without emitting (`tsc --noEmit`)
+- `npm run release` / `npm run releasePatch` - Build, test and publish (`releasePatch` bumps the patch version first)
 
 ## Architecture Overview
 
@@ -47,11 +49,12 @@ TinyMDE is a lightweight, embeddable Markdown editor with two main components:
 
 ### Testing
 
-- **Jest + Puppeteer** for browser-based testing
+- **Jest + Playwright** for browser-based testing
 - Tests located in `jest/` directory
 - Tests cover block parsing, inline formatting, command bar functionality, and user interactions
-- Configuration in `jest.config.js`
-- Run all tests with `npm run test`
+- Configuration in `jest.config.js`, which defines one Jest project per browser (chromium, firefox, webkit). Every test file runs in all three, so a test count is 3x the number of cases.
+- Shared helpers (`PATH`, `select()`, `initTinyMDE()`, `classTagRegExp()`) are globals set up by `jest/util/test-helpers.js`; the Playwright `page` is a global from `jest/util/multi-browser-setup.js`
+- `npm run test` builds via gulp first, so tests always run against `dist/` — source changes (including CSS) are picked up automatically
 - Run an individual test with `npm run test ${file}`, eg. `npm run test jest/commandbar.test.js`
 
 ### Key Features

--- a/jest/editor-background.test.js
+++ b/jest/editor-background.test.js
@@ -1,0 +1,91 @@
+// Regression tests for #182: when the content is taller than a fixed-height
+// editor container, the editor's background color stopped at the fold and the
+// container showed through below it.
+
+// blank.html gives us #tinymde as a 300px tall scroll container, which is the
+// setup from the issue.
+const CONTAINER_HEIGHT = 300;
+
+// Distinctive color for the container, so anything showing through underneath
+// the editor is unmistakable.
+const CONTAINER_BG = 'rgb(255, 0, 0)';
+
+// The editor's own background, from .TinyMDE in editor.css.
+const EDITOR_BG = [255, 255, 255];
+
+beforeEach(async () => {
+  await page.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(page);
+});
+
+const setupOverflowingEditor = async () => {
+  await page.evaluate((bg) => {
+    const container = document.getElementById('tinymde');
+    container.style.backgroundColor = bg;
+    const content = Array.from({ length: 40 }, (_, i) => `Line ${i + 1}`).join('\n');
+    document.tinyMDE = new TinyMDE.Editor({ element: 'tinymde', content: content });
+  }, CONTAINER_BG);
+};
+
+/**
+ * Screenshots the page and reads back a single pixel as [r, g, b], by decoding
+ * the PNG in the browser we already have open rather than pulling in an image
+ * library. The default Playwright context has a device scale factor of 1, so
+ * screenshot pixels and CSS pixels line up.
+ */
+const pixelAt = async (x, y) => {
+  const b64 = (await page.screenshot()).toString('base64');
+  return page.evaluate(async (args) => {
+    const img = new Image();
+    img.src = `data:image/png;base64,${args.b64}`;
+    await img.decode();
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    const data = ctx.getImageData(args.x, args.y, 1, 1).data;
+    return [data[0], data[1], data[2]];
+  }, { b64: b64, x: x, y: y });
+};
+
+test('Editor element grows to cover content taller than its container', async () => {
+  await setupOverflowingEditor();
+
+  const measured = await page.evaluate(() => {
+    const container = document.getElementById('tinymde');
+    const editor = container.querySelector('.TinyMDE');
+    return {
+      editorHeight: editor.getBoundingClientRect().height,
+      scrollHeight: container.scrollHeight,
+    };
+  });
+
+  // Sanity check that the content really does overflow the container.
+  expect(measured.scrollHeight).toBeGreaterThan(CONTAINER_HEIGHT);
+  // The background is painted by the editor element's box, so that box has to
+  // be at least as tall as the scrollable content.
+  expect(measured.editorHeight).toBeGreaterThanOrEqual(measured.scrollHeight);
+});
+
+test('Editor background is painted below the fold when scrolled to the bottom', async () => {
+  await setupOverflowingEditor();
+
+  await page.evaluate(() => {
+    const container = document.getElementById('tinymde');
+    container.scrollTop = container.scrollHeight;
+  });
+
+  // Sample near the bottom of the visible container, at 80% of the editor's
+  // width so we land to the right of the (short, left-aligned) line text.
+  const point = await page.evaluate(() => {
+    const containerRect = document.getElementById('tinymde').getBoundingClientRect();
+    const editorRect = document.querySelector('.TinyMDE').getBoundingClientRect();
+    return {
+      x: Math.round(editorRect.left + editorRect.width * 0.8),
+      y: Math.round(containerRect.bottom - 8),
+    };
+  });
+
+  expect(await pixelAt(point.x, point.y)).toEqual(EDITOR_BG);
+});

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -5,7 +5,11 @@
   line-height:24px;
   outline: none;
   padding:5px;
-  height: 100%;
+  /* min-height rather than height so the editor fills a fixed-height container
+     when it's near-empty, but still grows with the content when it overflows.
+     With height:100% the box stayed at the container's height and the
+     background stopped painting at the fold (#182). */
+  min-height: 100%;
 }
 
 .TinyMDE.TinyMDE_empty {


### PR DESCRIPTION
Fixes #182.

## Problem

`.TinyMDE` had `height: 100%` (`src/css/editor.css:8`). In a fixed-height container — e.g. the `height:300px; overflow-y:scroll` wrapper from the issue — the editor's box stayed at the container's height while its children overflowed it. The background is painted by that box, so everything scrolled past the fold showed the container through instead of the editor background.

## Fix

`min-height: 100%` instead. The editor still fills the container when it's near-empty, but now grows with the content when it overflows, so the background covers the full scrollable area. For an auto-height container both forms resolve the same way, so unsized containers are unaffected.

## Tests

Committed test-first, in `jest/editor-background.test.js` — 344cd18 adds them failing, 8e27302 makes them pass. Two angles:

- **Geometry:** the background is painted by the `.TinyMDE` box, so that box must be at least as tall as `container.scrollHeight`.
- **Pixel:** sets the container background to red, fills past the fold, scrolls to the bottom, screenshots, and samples one pixel below the fold — which is the symptom as reported. The PNG is decoded in the browser already open (data URL → canvas → `getImageData`) rather than by adding an image library. The default Playwright context has `deviceScaleFactor: 1`, so screenshot and CSS pixels line up.

Before the fix, in all three browsers:

```
expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 965      Received: 310

Array [ 255, -255, -255 ]   <- expected white
       [ 255, +0,   +0   ]   <- got the container red
```

Full suite green: 705 passed across chromium, firefox and webkit (699 before, +6 new).

## Also in this PR

A `docs:` commit correcting stale info in `CLAUDE.md`, noticed while writing the tests: it described the suite as Jest + **Puppeteer** (it's been Playwright for a while) and documented an `npm run prepublishOnly` script that no longer exists. Replaced with the scripts that do exist, plus the three-browser project layout and the global test helpers. Happy to split this out if you'd rather keep the PR to the fix.

## Not addressed

`.TinyMDE` has `padding: 5px` with default `content-box`, so `min-height: 100%` computes to container height **plus** 10px — a fixed-height container always has ~10px of spurious scroll (visible in the numbers above: 310 for a 300px container). `box-sizing: border-box` would fix it, but it shifts layout slightly for existing users and is a separate defect from #182, so I left it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GZM8Se4QqnhwfkAoRcdx4