### PR TITLE
fix: count the editor's padding towards its height

### DIFF
--- a/jest/editor-background.test.js
+++ b/jest/editor-background.test.js
@@ -68,6 +68,35 @@ test('Editor element grows to cover content taller than its container', async ()
   expect(measured.editorHeight).toBeGreaterThanOrEqual(measured.scrollHeight);
 });
 
+test('Editor does not overflow a fixed-height container when the content fits', async () => {
+  await page.evaluate(() => {
+    document.tinyMDE = new TinyMDE.Editor({ element: 'tinymde', content: 'Line 1\nLine 2\nLine 3' });
+  });
+
+  const measured = await page.evaluate(() => {
+    const container = document.getElementById('tinymde');
+    const editor = container.querySelector('.TinyMDE');
+    const firstLine = editor.firstChild;
+    return {
+      scrollHeight: container.scrollHeight,
+      clientHeight: container.clientHeight,
+      // The editor's padding has to survive the box-sizing change, so check
+      // that the text is still inset rather than flush against the box.
+      textInsetTop: Math.round(
+        firstLine.getBoundingClientRect().top - editor.getBoundingClientRect().top
+      ),
+      textInsetLeft: Math.round(
+        firstLine.getBoundingClientRect().left - editor.getBoundingClientRect().left
+      ),
+    };
+  });
+
+  // The editor's own padding must not push it past the container height.
+  expect(measured.scrollHeight).toEqual(measured.clientHeight);
+  expect(measured.textInsetTop).toEqual(5);
+  expect(measured.textInsetLeft).toEqual(5);
+});
+
 test('Editor background is painted below the fold when scrolled to the bottom', async () => {
   await setupOverflowingEditor();
 

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -5,6 +5,10 @@
   line-height:24px;
   outline: none;
   padding:5px;
+  /* Count the padding towards the height below, so a fixed-height container
+     doesn't end up 10px short of fitting its own editor. Also makes the box
+     behave the same whether or not the embedding page has a border-box reset. */
+  box-sizing: border-box;
   /* min-height rather than height so the editor fills a fixed-height container
      when it's near-empty, but still grows with the content when it overflows.
      With height:100% the box stayed at the container's height and the


### PR DESCRIPTION
Follow-up to #184, split out so it can be reviewed and reverted on its own.

## Problem

`.TinyMDE` has `padding: 5px` and no `box-sizing`, so `min-height: 100%` resolves to the container's height *plus* 10px of padding. A fixed-height container is therefore always 10px short of fitting its own editor, leaving a scrollbar and 10px of scroll with nothing in it.

## Measured effect

Chromium, across the configurations that can differ:

| Scenario | Before | After |
|---|---|---|
| Fixed-height container, content fits | editor 310px, scrollHeight 310 vs client 300 | editor 300px, scrollHeight 300 |
| Fixed-height container, content overflows | 970px | 970px (unchanged) |
| Auto-height container | 82px | 82px (unchanged) |
| Caller overrides `.TinyMDE { height: 400px }` | 410px | 400px |

Nothing moves horizontally or textually in any case: padding is still 5px, and `box-sizing` has no effect on a `width: auto` block box (measured 1280px throughout).

The overflow case — the subject of #184 — is unaffected, because once content exceeds the container the height is content-driven and `min-height` doesn't bind.

## Why this is a consistency fix, not just a behavior change

An embedding page with a `* { box-sizing: border-box }` reset (Tailwind preflight, Bootstrap, most normalize setups) already produces the "after" numbers today. The editor's box height currently depends on whether the host page has a reset; this makes it the same either way.

The users who see a change are those with a fixed-height container, no CSS reset, and content that fits — and the change is that a scrollbar which shouldn't have been there goes away.

## Tests

One case added to `jest/editor-background.test.js`: a fixed-height container with content that fits must have `scrollHeight === clientHeight`, plus assertions that the text is still inset 5px from the box so the padding can't be silently lost to the box-sizing change. Fails 310 vs 300 in all three browsers before the fix.

Full suite green: 708 passed across chromium, firefox and webkit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GZM8Se4QqnhwfkAoRcdx4