### PR TITLE
harden: bind the test server to loopback and fail loudly on port conflict

### DIFF
--- a/jest/util/config.js
+++ b/jest/util/config.js
@@ -1,2 +1,7 @@
 const PORT = 8880;
+// Loopback only - the test server has no reason to be reachable off-box. Kept
+// as an IP rather than "localhost" so the server and the browsers agree on a
+// family: "localhost" can resolve to ::1 on one side and 127.0.0.1 on the other.
+const HOST = '127.0.0.1';
 exports.PORT = PORT;
+exports.HOST = HOST;

--- a/jest/util/server.js
+++ b/jest/util/server.js
@@ -1,33 +1,87 @@
 const express = require('express');
+const http = require('http');
 const path = require('path');
-const { PORT } = require("./config");
+const { PORT, HOST } = require("./config");
 
 let server;
 let serverStarted = false;
+
+/**
+ * Checks whether whatever is already listening on PORT is a TinyMDE test
+ * server, by asking it for a file we know we serve and looking for a marker in
+ * the response. A status code alone isn't enough - plenty of servers answer 200
+ * to anything. Resolves false for anything unrecognized, including a non-HTTP
+ * listener.
+ */
+const isOurServer = () => new Promise((resolve) => {
+  const request = http.get(
+    { host: HOST, port: PORT, path: '/blank.html', timeout: 2000 },
+    (response) => {
+      if (response.statusCode !== 200) {
+        response.resume(); // Drain, so the socket can close.
+        resolve(false);
+        return;
+      }
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => { body += chunk; });
+      response.on('end', () => resolve(body.includes('tiny-mde.js')));
+      response.on('error', () => resolve(false));
+    }
+  );
+  request.on('error', () => resolve(false));
+  request.on('timeout', () => {
+    request.destroy();
+    resolve(false);
+  });
+});
 
 const startServer = () => {
   if (serverStarted && server) {
     return Promise.resolve();
   }
-  
+
   return new Promise((resolve, reject) => {
     const app = express();
     app.use('/', express.static(path.resolve(__dirname, '..', '..', 'dist')));
-    server = app.listen(PORT, () => {
-      console.log(`Serving TinyMDE files at http://localhost:${PORT}/`);
+    // Bind to loopback explicitly. Without a host, Node listens on every
+    // interface, which needlessly exposes the test server to the network for
+    // the length of the run - on a shared or self-hosted CI runner, to anything
+    // that can reach it.
+    //
+    // Deliberately no callback argument here: express's app.listen() wraps a
+    // trailing callback in once() and *also* registers it as the server's error
+    // handler, so a failed bind would invoke it as though the listen had
+    // succeeded. Listening for the events directly keeps the two apart.
+    server = app.listen(PORT, HOST);
+
+    server.on('listening', () => {
+      console.log(`Serving TinyMDE files at http://${HOST}:${PORT}/`);
       serverStarted = true;
       resolve();
     });
-    
-    server.on('error', (error) => {
-      if (error.code === 'EADDRINUSE') {
-        console.log(`Port ${PORT} is already in use, assuming server is already running`);
-        serverStarted = true;
-        server = null; // Don't hold reference to server we don't control
-        resolve();
-      } else {
+
+    server.on('error', async (error) => {
+      if (error.code !== 'EADDRINUSE') {
         reject(error);
+        return;
       }
+      // A second test run against the same checkout can share a server, so a
+      // busy port isn't necessarily a problem - but only once we've confirmed
+      // it's ours. Silently assuming would mean testing against whatever else
+      // happens to be on this port, and reporting the results as if they were
+      // ours.
+      if (await isOurServer()) {
+        console.log(`Port ${PORT} is already serving the TinyMDE test files, reusing it`);
+        serverStarted = true;
+        server = null; // Don't hold a reference to a server we don't control.
+        resolve();
+        return;
+      }
+      reject(new Error(
+        `Port ${PORT} is in use by something that is not the TinyMDE test server. ` +
+        `Stop whatever is listening on ${HOST}:${PORT}, or change PORT in jest/util/config.js.`
+      ));
     });
   });
 };

--- a/jest/util/server.js
+++ b/jest/util/server.js
@@ -1,40 +1,9 @@
 const express = require('express');
-const http = require('http');
 const path = require('path');
 const { PORT, HOST } = require("./config");
 
 let server;
 let serverStarted = false;
-
-/**
- * Checks whether whatever is already listening on PORT is a TinyMDE test
- * server, by asking it for a file we know we serve and looking for a marker in
- * the response. A status code alone isn't enough - plenty of servers answer 200
- * to anything. Resolves false for anything unrecognized, including a non-HTTP
- * listener.
- */
-const isOurServer = () => new Promise((resolve) => {
-  const request = http.get(
-    { host: HOST, port: PORT, path: '/blank.html', timeout: 2000 },
-    (response) => {
-      if (response.statusCode !== 200) {
-        response.resume(); // Drain, so the socket can close.
-        resolve(false);
-        return;
-      }
-      let body = '';
-      response.setEncoding('utf8');
-      response.on('data', (chunk) => { body += chunk; });
-      response.on('end', () => resolve(body.includes('tiny-mde.js')));
-      response.on('error', () => resolve(false));
-    }
-  );
-  request.on('error', () => resolve(false));
-  request.on('timeout', () => {
-    request.destroy();
-    resolve(false);
-  });
-});
 
 const startServer = () => {
   if (serverStarted && server) {
@@ -61,25 +30,20 @@ const startServer = () => {
       resolve();
     });
 
-    server.on('error', async (error) => {
+    server.on('error', (error) => {
       if (error.code !== 'EADDRINUSE') {
         reject(error);
         return;
       }
-      // A second test run against the same checkout can share a server, so a
-      // busy port isn't necessarily a problem - but only once we've confirmed
-      // it's ours. Silently assuming would mean testing against whatever else
-      // happens to be on this port, and reporting the results as if they were
-      // ours.
-      if (await isOurServer()) {
-        console.log(`Port ${PORT} is already serving the TinyMDE test files, reusing it`);
-        serverStarted = true;
-        server = null; // Don't hold a reference to a server we don't control.
-        resolve();
-        return;
-      }
+      // Never reuse someone else's server. This used to assume a busy port
+      // meant our own server was already up, which would run the whole suite
+      // against whatever happened to be listening and report the results as
+      // ours. A second worktree is the likely case, and its server serves a
+      // different dist/ - so the suite would pass or fail on the wrong build.
       reject(new Error(
-        `Port ${PORT} is in use by something that is not the TinyMDE test server. ` +
+        `Port ${PORT} is already in use, so the test server could not start. ` +
+        `Another test run (possibly in a different worktree) is the likely cause; ` +
+        `its server would be serving a different dist/. ` +
         `Stop whatever is listening on ${HOST}:${PORT}, or change PORT in jest/util/config.js.`
       ));
     });

--- a/jest/util/test-helpers.js
+++ b/jest/util/test-helpers.js
@@ -1,6 +1,6 @@
-const { PORT } = require("./config");
+const { PORT, HOST } = require("./config");
 
-global.PATH = `http://localhost:${PORT}/blank.html`;
+global.PATH = `http://${HOST}:${PORT}/blank.html`;
 
 global.waitForTinyMDE = async (page) => {
   await page.waitForFunction(() => typeof TinyMDE !== 'undefined', { timeout: 10000 });


### PR DESCRIPTION
Test-infrastructure hardening for `jest/util/server.js`. This is the alternative to #187, which flagged a missing CSRF middleware on this server — see the note at the bottom.

Three related fixes.

## 1. Bind to loopback

`app.listen(PORT)` with no host makes Node listen on **every interface**, so the test server is reachable off-box for the length of a run. On GitHub-hosted runners the VM is ephemeral with no inbound reachability, so the practical risk today is low — but it's gratuitous, and it becomes real on a shared or self-hosted runner.

Now binds `127.0.0.1`. `HOST` lives in `config.js` next to `PORT`, and `PATH` in `test-helpers.js` uses it too, so the server and the browsers can't disagree about IPv4 vs IPv6 the way they could when one side said `localhost`.

Confirmed with `ss`:

```
LISTEN 0  511  127.0.0.1:8880  0.0.0.0:*     # was 0.0.0.0:8880
```

## 2. A port conflict reported success

This one turned out to be a live bug rather than hardening. Express's `app.listen()` wraps a trailing callback in `once()` and **also registers it as the server's error handler**:

```js
// express/lib/application.js:598
var done = args[args.length - 1] = once(args[args.length - 1])
server.once('error', done)
```

So on `EADDRINUSE`, express invoked our *success* callback. On `main` today, a port conflict logs `Serving TinyMDE files at http://localhost:8880/` and resolves the start promise, as though the server had come up. Plain `http.createServer().listen()` doesn't behave this way — it's specific to going through express.

Fixed by not handing express a callback and listening for `listening` and `error` separately.

## 3. Never reuse the port's occupant

The `EADDRINUSE` branch assumed a busy port meant our own server was already running: it logged "assuming server is already running", dropped the server reference, and resolved.

That's unsafe. The likely cause of a conflict is a **second worktree**, whose server is serving a *different* `dist/` — so the suite would run against the wrong build and report the result as if it were this checkout's, turning a real failure into a pass or vice versa. Probing the occupant to check it's "one of ours" doesn't help, because `blank.html` is identical across worktrees.

So a busy port now fails outright, with a message naming the likely cause:

```
Port 8880 is already in use, so the test server could not start. Another test run
(possibly in a different worktree) is the likely cause; its server would be serving
a different dist/. Stop whatever is listening on 127.0.0.1:8880, or change PORT in
jest/util/config.js.
```

Nothing in the suite depended on reuse — Jest dedupes the shared `globalSetup` across the three browser projects, so it starts exactly one server per run (verified: one `Serving TinyMDE files` line). The cost is that concurrent `test:chromium` / `test:firefox` runs on one machine now need different ports, which is the correct trade for not silently testing the wrong build.

## Verification

Checked by hand: port free → starts normally; port held by any server, including a genuine TinyMDE test server → rejects with the message above.

Full suite green: 708 passed across chromium, firefox and webkit.

## Relationship to #187

#187 proposed adding CSRF protection here. CSRF doesn't apply to this server: its only middleware is `express.static`, which serves GET/HEAD only, and there are no cookies, sessions, or auth — nothing to forge and no ambient authority to forge it with. The semgrep rule is an `.audit.` rule, which flags patterns for review rather than asserting exploitability, and its suggested remedy (`csurf`) has been npm-deprecated with its repo archived since 2022.

That PR's diff is also a one-line `// nosemgrep` suppression rather than the CSRF protection its title describes, and semgrep isn't wired into this repo, so the comment silences a scanner that never runs here. Its stated threat model ("vulnerabilities affect downstream consumers") doesn't hold either: `package.json` `files` is `["dist/*", "lib/**/*.js", "lib/**/*.d.ts"]`, so `jest/util/` is never published, and `express` is a devDependency.

This PR fixes what was actually wrong with the file instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GZM8Se4QqnhwfkAoRcdx4