### PR TITLE
Add destroy() to Editor and CommandBar

### DIFF
--- a/jest/destroy.test.js
+++ b/jest/destroy.test.js
@@ -1,0 +1,133 @@
+test('Editor.destroy() removes the element it created itself from the DOM', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const result = await newPage.evaluate(() => {
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde' });
+    const existedBefore = !!document.querySelector('.TinyMDE');
+    tinyMDE.destroy();
+    return { existedBefore, existsAfter: !!document.querySelector('.TinyMDE') };
+  });
+
+  expect(result.existedBefore).toBe(true);
+  expect(result.existsAfter).toBe(false);
+  newPage.close();
+});
+
+test('Editor.destroy() detaches (but does not remove) a caller-provided editor element', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const result = await newPage.evaluate(() => {
+    const editorEl = document.createElement('div');
+    document.body.appendChild(editorEl);
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde', editor: editorEl });
+    tinyMDE.destroy();
+    return {
+      stillInDom: document.body.contains(editorEl),
+      hasEditorClass: editorEl.classList.contains('TinyMDE'),
+      contentEditable: editorEl.getAttribute('contenteditable'),
+    };
+  });
+
+  expect(result.stillInDom).toBe(true);
+  expect(result.hasEditorClass).toBe(false);
+  expect(result.contentEditable).toBeNull();
+  newPage.close();
+});
+
+test('Editor.destroy() restores the linked textarea visibility', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const result = await newPage.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde', textarea: textarea });
+    const hiddenBefore = textarea.style.display === 'none';
+    tinyMDE.destroy();
+    return { hiddenBefore, hiddenAfter: textarea.style.display === 'none' };
+  });
+
+  expect(result.hiddenBefore).toBe(true);
+  expect(result.hiddenAfter).toBe(false);
+  newPage.close();
+});
+
+test('Editor.destroy() removes the document-level selectionchange listener', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const result = await newPage.evaluate(() => {
+    let added = 0;
+    let removed = 0;
+    const originalAdd = document.addEventListener.bind(document);
+    const originalRemove = document.removeEventListener.bind(document);
+    document.addEventListener = (type, ...args) => {
+      if (type === 'selectionchange') added++;
+      return originalAdd(type, ...args);
+    };
+    document.removeEventListener = (type, ...args) => {
+      if (type === 'selectionchange') removed++;
+      return originalRemove(type, ...args);
+    };
+
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde' });
+    tinyMDE.destroy();
+
+    document.addEventListener = originalAdd;
+    document.removeEventListener = originalRemove;
+    return { added, removed };
+  });
+
+  expect(result.added).toBeGreaterThan(0);
+  expect(result.removed).toEqual(result.added);
+  newPage.close();
+});
+
+test('Editor.destroy() is safe to call more than once', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const promise = newPage.evaluate(() => {
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde' });
+    tinyMDE.destroy();
+    tinyMDE.destroy();
+  });
+
+  await expect(promise).resolves.not.toThrow();
+  newPage.close();
+});
+
+test('CommandBar.destroy() removes its element and detaches from the editor', async () => {
+  const newPage = await global.context.newPage();
+  await newPage.goto(PATH, { waitUntil: 'load' });
+  await global.waitForTinyMDE(newPage);
+
+  const result = await newPage.evaluate(() => {
+    const tinyMDE = new TinyMDE.Editor({ element: 'tinymde' });
+    const commandBar = new TinyMDE.CommandBar({ element: 'tinymde_commandbar', editor: tinyMDE });
+    const existedBefore = !!document.querySelector('.TMCommandBar');
+    const selectionListenersBefore = tinyMDE.listeners.selection.length;
+
+    commandBar.destroy();
+
+    return {
+      existedBefore,
+      existsAfter: !!document.querySelector('.TMCommandBar'),
+      selectionListenersBefore,
+      selectionListenersAfter: tinyMDE.listeners.selection.length,
+    };
+  });
+
+  expect(result.existedBefore).toBe(true);
+  expect(result.existsAfter).toBe(false);
+  expect(result.selectionListenersBefore).toBe(1);
+  expect(result.selectionListenersAfter).toBe(0);
+  newPage.close();
+});

--- a/src/TinyMDE.ts
+++ b/src/TinyMDE.ts
@@ -68,6 +68,9 @@ export class Editor {
   private hasFocus: boolean = true;
   private lastSelection: { focus: Position | null; anchor: Position | null } | null = null;
   private placeholder: string | undefined;
+  private cleanupFns: (() => void)[] = [];
+  private ownsElement: boolean = false;
+  private destroyed: boolean = false;
 
   public listeners: {
     change: EventHandler<ChangeEvent>[];
@@ -153,7 +156,7 @@ export class Editor {
         : "# Hello TinyMDE!\nEdit **here**"
     );
     
-    this.e!.addEventListener("keydown", (e) => this.handleUndoRedoKey(e));
+    this.addListener(this.e!, "keydown", (e: Event) => this.handleUndoRedoKey(e as KeyboardEvent));
   }
 
   get canUndo(): boolean {
@@ -229,6 +232,7 @@ export class Editor {
       }
     } else {
       this.e = document.createElement("div");
+      this.ownsElement = true;
     }
 
     this.e.classList.add("TinyMDE");
@@ -252,18 +256,17 @@ export class Editor {
       }
     }
 
-    this.e.addEventListener("input", (e) => this.handleInputEvent(e));
-    this.e.addEventListener("beforeinput", (e) => this.handleBeforeInputEvent(e));
-    this.e.addEventListener("compositionend", (e) => this.handleInputEvent(e));
-    document.addEventListener("selectionchange", (e) => {
+    this.addListener(this.e, "input", (e: Event) => this.handleInputEvent(e));
+    this.addListener(this.e, "beforeinput", (e: Event) => this.handleBeforeInputEvent(e));
+    this.addListener(this.e, "compositionend", (e: Event) => this.handleInputEvent(e));
+    this.addListener(document, "selectionchange", (e: Event) => {
       if (this.hasFocus) { this.handleSelectionChangeEvent(e); }
-      }
-    );
-    this.e.addEventListener("blur", () => this.hasFocus = false );
-    this.e.addEventListener("focus", () => this.hasFocus = true );
-    this.e.addEventListener("paste", (e) => this.handlePaste(e));
-    this.e.addEventListener("drop", (e) => this.handleDrop(e));
-    this.e.addEventListener("click", (e) => this.handleClick(e));
+    });
+    this.addListener(this.e, "blur", () => this.hasFocus = false );
+    this.addListener(this.e, "focus", () => this.hasFocus = true );
+    this.addListener(this.e, "paste", (e: Event) => this.handlePaste(e as ClipboardEvent));
+    this.addListener(this.e, "drop", (e: Event) => this.handleDrop(e as DragEvent));
+    this.addListener(this.e, "click", (e: Event) => this.handleClick(e as MouseEvent));
     this.lineElements = this.e.childNodes;
   }
 
@@ -895,6 +898,60 @@ export class Editor {
     if (type.match(editorRegExp.dropEvent)) {
       this.listeners.drop.push(listener as EventHandler<DropEvent>);
     }
+  }
+
+  public removeEventListener<T extends EventType>(
+    type: T,
+    listener: T extends 'change' ? EventHandler<ChangeEvent> :
+             T extends 'selection' ? EventHandler<SelectionEvent> :
+             T extends 'drop' ? EventHandler<DropEvent> : never
+  ): void {
+    if (type.match(editorRegExp.changeEvent)) {
+      this.listeners.change = this.listeners.change.filter((l) => l !== listener);
+    }
+    if (type.match(editorRegExp.selectionEvent)) {
+      this.listeners.selection = this.listeners.selection.filter((l) => l !== listener);
+    }
+    if (type.match(editorRegExp.dropEvent)) {
+      this.listeners.drop = this.listeners.drop.filter((l) => l !== listener);
+    }
+  }
+
+  private addListener(target: EventTarget, type: string, handler: EventListenerOrEventListenerObject): void {
+    target.addEventListener(type, handler);
+    this.cleanupFns.push(() => target.removeEventListener(type, handler));
+  }
+
+  /**
+   * Removes all DOM/document listeners registered by this instance (including the
+   * `document`-level selectionchange listener, which would otherwise keep the whole editor
+   * alive for as long as the page lives) and detaches the editor element it created itself.
+   * Safe to call multiple times.
+   */
+  public destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+
+    for (const cleanup of this.cleanupFns) cleanup();
+    this.cleanupFns = [];
+
+    if (this.e) {
+      if (this.ownsElement) {
+        if (this.e.parentNode) this.e.parentNode.removeChild(this.e);
+      } else {
+        this.e.classList.remove("TinyMDE", "TinyMDE_empty");
+        this.e.removeAttribute("contenteditable");
+        this.e.removeAttribute("data-placeholder");
+      }
+    }
+
+    if (this.textarea) {
+      this.textarea.style.display = "";
+    }
+
+    this.listeners = { change: [], selection: [], drop: [] };
+    this.e = null;
+    this.textarea = null;
   }
 
   private fireChange(): void {

--- a/src/TinyMDECommandBar.ts
+++ b/src/TinyMDECommandBar.ts
@@ -158,6 +158,8 @@ export class CommandBar {
   public buttons: Record<string, HTMLDivElement> = {};
   public state: Record<string, boolean | null> = {};
   private hotkeys: Hotkey[] = [];
+  private cleanupFns: (() => void)[] = [];
+  private destroyed: boolean = false;
 
   constructor(props: CommandBarProps) {
     this.e = null;
@@ -204,7 +206,7 @@ export class CommandBar {
         "insertImage",
       ]
     );
-    document.addEventListener("keydown", (e) => this.handleKeydown(e));
+    this.addListener(document, "keydown", (e: Event) => this.handleKeydown(e as KeyboardEvent));
     if (props.editor) this.setEditor(props.editor);
   }
 
@@ -310,7 +312,7 @@ export class CommandBar {
         this.buttons[commandName].title = title;
         this.buttons[commandName].innerHTML = this.commands[commandName].innerHTML || "?";
 
-        this.buttons[commandName].addEventListener("mousedown", (e) =>
+        this.addListener(this.buttons[commandName], "mousedown", (e: Event) =>
           this.handleClick(commandName, e)
         );
         this.e.appendChild(this.buttons[commandName]);
@@ -344,7 +346,9 @@ export class CommandBar {
 
   public setEditor(editor: Editor): void {
     this.editor = editor;
-    editor.addEventListener("selection", (e) => this.handleSelection(e));
+    const handler = (e: SelectionEvent) => this.handleSelection(e);
+    editor.addEventListener("selection", handler);
+    this.cleanupFns.push(() => editor.removeEventListener("selection", handler));
   }
 
   private handleSelection(event: SelectionEvent): void {
@@ -392,6 +396,32 @@ export class CommandBar {
         return;
       }
     }
+  }
+
+  private addListener(target: EventTarget, type: string, handler: EventListenerOrEventListenerObject): void {
+    target.addEventListener(type, handler);
+    this.cleanupFns.push(() => target.removeEventListener(type, handler));
+  }
+
+  /**
+   * Removes all listeners registered by this instance, including the document-level keydown
+   * listener and the selection listener on its editor, and detaches the command bar element.
+   * Safe to call multiple times.
+   */
+  public destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+
+    for (const cleanup of this.cleanupFns) cleanup();
+    this.cleanupFns = [];
+
+    if (this.e && this.e.parentNode) {
+      this.e.parentNode.removeChild(this.e);
+    }
+
+    this.editor = null;
+    this.e = null;
+    this.buttons = {};
   }
 }
 


### PR DESCRIPTION
## Summary
- Editor.destroy() removes every DOM/document listener it registered (including the
  document-level `selectionchange` listener, the real source of the leak) and detaches
  the element it created.
- CommandBar.destroy() does the same, and detaches from its Editor via a new
  Editor.removeEventListener().
- Both are idempotent (safe to call twice).

## Test plan
- [x] npm run typecheck
- [x] npm run test:chromium (242/242)
- New tests in jest/destroy.test.js cover: element removal/detachment, textarea
  restoration, selectionchange listener cleanup, idempotency, CommandBar detachment.

Closes #191